### PR TITLE
Configure CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+* @signalfx/gdi-dotnet-approvers
+
+CODEOWNERS @signalfx/gdi-dotnet-maintainers
+
+#####################################################
+#
+# Docs reviewers
+#
+#####################################################
+
+*.md @signalfx/gdi-docs @signalfx/gdi-dotnet-approvers
+*.rst @signalfx/gdi-docs @signalfx/gdi-dotnet-approvers
+docs/ @signalfx/gdi-docs @signalfx/gdi-dotnet-approvers
+README* @signalfx/gdi-docs @signalfx/gdi-dotnet-approvers


### PR DESCRIPTION
Taken from https://github.com/signalfx/signalfx-dotnet-tracing/blob/main/.github/CODEOWNERS