### PR TITLE
Release 0.0.1-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Changelog
 
-All notable changes to this project are documented in this file.
+All notable changes to this component are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
-This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/signalfx/splunk-otel-dotnet/compare/805704f44c84228a881c24b1447a953564d5461e...HEAD)
+## [Unreleased](https://github.com/signalfx/splunk-otel-dotnet/compare/v0.0.1-alpha.2...HEAD)
 
 ### Added
 
@@ -18,6 +18,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 ### Security
+
+## [0.0.1-alpha.2](https://github.com/signalfx/splunk-otel-dotnet/releases/tag/v0.0.1-alpha.2)
+
+The is an alpha release,
+built on top of [OpenTelemetry .NET Auto Instrumentation v0.4.0-beta.1](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v0.4.0-beta.1).
 
 ## [0.0.1-alpha.1](https://github.com/signalfx/splunk-otel-dotnet/releases/tag/v0.0.1-alpha.1)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Splunk Distribution of OpenTelemetry .NET
 
 [![OpenTelemetry .NET](https://img.shields.io/badge/OTel-1.3.1-blueviolet)](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.3.1)
-[![OpenTelemetry .NET Auto Instrumentation](https://img.shields.io/badge/OTel-v0.3.1-blueviolet)](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v0.3.1-beta.1)
+[![OpenTelemetry .NET Auto Instrumentation](https://img.shields.io/badge/OTel-v0.4.0-blueviolet)](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v0.4.0-beta.1)
 [![Splunk GDI Specification](https://img.shields.io/badge/GDI-1.3.0-blueviolet)](https://github.com/signalfx/gdi-specification/releases/tag/v1.3.0)
 [![Keep a Changelog](https://img.shields.io/badge/changelog-Keep%20a%20Changelog-%23E05735)](CHANGELOG.md)
 [![LICENSE](https://img.shields.io/github/license/signalfx/splunk-otel-dotnet)](LICENSE)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,14 +4,15 @@ Versioning is using [MinVer](https://github.com/adamralph/minver).
 No changes in the code are needed to correctly version this package.
 
 1. Update the version in the following files:
-   - [`Splunk.OTel.DotNet.psm1`](../Splunk.OTel.DotNet.psm1#L182)
-   - [`docs/README.md`](./README.md)
+   - [`splunk-otel-dotnet-install.sh`](splunk-otel-dotnet-install.sh#L34)
+   - [`Splunk.OTel.DotNet.psm1`](Splunk.OTel.DotNet.psm1#L184)
+   - [`docs/README.md`](docs/README.md)
 
-1. Update the [CHANGELOG.md](../CHANGELOG.md) with the new release.
+1. Update the [CHANGELOG.md](CHANGELOG.md) with the new release.
 
 1. Create a pull request on GitHub with the changes described in the changelog.
-
-1. Test the described [examples](../examples/README.md).
+   - `*scripts*` and `validate-documentation` jobs will fail
+     because the release is not published yet.
 
 1. Once the pull request has been merged, create a signed tag for the merged commit.
    You can do this using the following Bash snippet:
@@ -20,13 +21,13 @@ No changes in the code are needed to correctly version this package.
    TAG='v{new-version-here}'
    COMMIT='{commit-sha-here}'
    git tag -s -m $TAG $TAG $COMMIT
-   git push {remote-to-the-main-repo} $TAG
+   git push upstream $TAG
    ```
 
    After you've pushed the git tag, a `ci` GitHub workflow starts.
 
 1. Publish a release in GitHub:
 
-   - Use the [CHANGELOG.md](../CHANGELOG.md) content in the description.
+   - Use the [CHANGELOG.md](CHANGELOG.md) content in the description.
    - Add the artifacts from [the `ci` GitHub workflow](https://github.com/signalfx/splunk-otel-dotnet/actions/workflows/ci.yml)
      related to the created tag.

--- a/Splunk.OTel.DotNet.psm1
+++ b/Splunk.OTel.DotNet.psm1
@@ -46,7 +46,7 @@ function Reset-IIS() {
 }
 
 function Download-OpenTelemetry([string]$Version, [string]$Path) {
-    $archive = "splunk-opentelemetry-dotnet-instrumentation-windows.zip"
+    $archive = "splunk-opentelemetry-dotnet-windows.zip"
     $dlUrl = "https://github.com/signalfx/splunk-otel-dotnet/releases/download/$Version/$archive"
     $dlPath = Join-Path $Path $archive
 

--- a/Splunk.OTel.DotNet.psm1
+++ b/Splunk.OTel.DotNet.psm1
@@ -181,7 +181,7 @@ function Install-OpenTelemetryCore() {
         [string]$InstallDir = "<auto>"
     )
 
-    $version = "v0.0.1-alpha.1"
+    $version = "v0.0.1-alpha.2"
     $installDir = Get-CLIInstallDir-From-InstallDir $InstallDir
     $tempDir = Get-Temp-Directory
     $dlPath = $null

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -14,7 +14,7 @@ class Build : NukeBuild
     [Parameter("Configuration to build - Default is 'Release'")]
     readonly Configuration Configuration = Configuration.Release;
 
-    const string OpenTelemetryAutoInstrumentationDefaultVersion = "v0.3.1-beta.1";
+    const string OpenTelemetryAutoInstrumentationDefaultVersion = "v0.4.0-beta.1";
     [Parameter($"OpenTelemetry AutoInstrumentation dependency version - Default is '{OpenTelemetryAutoInstrumentationDefaultVersion}'")]
     readonly string OpenTelemetryAutoInstrumentationVersion = OpenTelemetryAutoInstrumentationDefaultVersion;
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ and instrument your .NET application using the official shell scripts.
 For example:
 
 ```sh
-curl -sSfL https://raw.githubusercontent.com/signalfx/splunk-otel-dotnet/v0.0.1-alpha.1/splunk-otel-dotnet-install.sh -O
+curl -sSfL https://raw.githubusercontent.com/signalfx/splunk-otel-dotnet/v0.0.1-alpha.2/splunk-otel-dotnet-install.sh -O
 sh ./splunk-otel-dotnet-install.sh
 . $HOME/.splunk-otel-dotnet/instrument.sh
 OTEL_SERVICE_NAME=myapp OTEL_RESOURCE_ATTRIBUTES=deployment.environment=staging,service.version=1.0.0 dotnet run
@@ -37,7 +37,7 @@ It uses environment variables as parameters:
 | `OTEL_DOTNET_AUTO_HOME` | Location where binaries are to be installed                      | No       | `$HOME/.splunk-otel-dotnet` |
 | `OS_TYPE`               | Possible values: `linux-glibc`, `linux-musl`, `macos`, `windows` | No       | *Calculated*              |
 | `TMPDIR`                | Temporary directory used when downloading the files              | No       | `$(mktemp -d)`            |
-| `VERSION`               | Version to download                                              | No       | `v0.0.1-alpha.1`           |
+| `VERSION`               | Version to download                                              | No       | `v0.0.1-alpha.2`           |
 
 The [instrument.sh](../instrument.sh) script
 enables the instrumentation in the current shell session.
@@ -61,7 +61,7 @@ For example:
 
 ```powershell
 # Download and import the module
-$module_url = "https://github.com/signalfx/splunk-otel-dotnet/releases/download/v0.0.1-alpha.1/Splunk.OTel.DotNet.psm1"
+$module_url = "https://github.com/signalfx/splunk-otel-dotnet/releases/download/v0.0.1-alpha.2/Splunk.OTel.DotNet.psm1"
 $download_path = Join-Path $env:temp "Splunk.OTel.DotNet.psm1"
 Invoke-WebRequest -Uri $module_url -OutFile $download_path
 Import-Module $download_path

--- a/docs/README.md
+++ b/docs/README.md
@@ -97,7 +97,7 @@ the [Advanced configuration](advanced-config.md) documentation.
 
 ## Manual instrumentation
 
-See [manual-instrumentation.md](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/v0.3.1-beta.1/docs/manual-instrumentation.md).
+See [manual-instrumentation.md](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/v0.4.0-beta.1/docs/manual-instrumentation.md).
 
 ## Migrating
 

--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -2,7 +2,7 @@
 
 ## OpenTelemetry configuration
 
-See [Open Telemetry Auto Instrumentation documentation](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/v0.3.1-beta.1/docs/config.md)
+See [Open Telemetry Auto Instrumentation documentation](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/v0.4.0-beta.1/docs/config.md)
 for configuration details.
 
 ## Splunk distribution configuration
@@ -18,7 +18,7 @@ Download and install the latest binaries from
 
 When running your application, make sure to:
 
-1. Set the [resources](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/v0.3.1-beta.1/docs/config.md#resources).
+1. Set the [resources](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/v0.4.0-beta.1/docs/config.md#resources).
 1. Set the environment variables from the table below.
 
 | Environment variable                 | .NET version           | Value                                                                          |
@@ -39,4 +39,4 @@ When running your application, make sure to:
 | `OTEL_DOTNET_AUTO_HOME`              | All versions           | `$INSTALL_DIR`                                                                 |
 | `OTEL_DOTNET_AUTO_INTEGRATIONS_FILE` | All versions           | `$INSTALL_DIR/integrations.json`                                               |
 
-> Some settings can be omitted on .NET (Core). For more information, see the [documentation](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/v0.3.1-beta.1/docs/config.md#net-clr-profiler).
+> Some settings can be omitted on .NET (Core). For more information, see the [documentation](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/v0.4.0-beta.1/docs/config.md#net-clr-profiler).

--- a/splunk-otel-dotnet-install.sh
+++ b/splunk-otel-dotnet-install.sh
@@ -31,7 +31,7 @@ esac
 
 test -z "$OTEL_DOTNET_AUTO_HOME" && OTEL_DOTNET_AUTO_HOME="$HOME/.splunk-otel-dotnet"
 test -z "$TMPDIR" && TMPDIR="$(mktemp -d)"
-test -z "$VERSION" && VERSION="v0.0.1-alpha.1"
+test -z "$VERSION" && VERSION="v0.0.1-alpha.2"
 
 RELEASES_URL="https://github.com/signalfx/splunk-otel-dotnet/releases"
 ARCHIVE="splunk-opentelemetry-dotnet-instrumentation-$OS_TYPE.zip"

--- a/splunk-otel-dotnet-install.sh
+++ b/splunk-otel-dotnet-install.sh
@@ -34,7 +34,7 @@ test -z "$TMPDIR" && TMPDIR="$(mktemp -d)"
 test -z "$VERSION" && VERSION="v0.0.1-alpha.2"
 
 RELEASES_URL="https://github.com/signalfx/splunk-otel-dotnet/releases"
-ARCHIVE="splunk-opentelemetry-dotnet-instrumentation-$OS_TYPE.zip"
+ARCHIVE="splunk-opentelemetry-dotnet-$OS_TYPE.zip"
 
 TMPFILE="$TMPDIR/$ARCHIVE"
 (


### PR DESCRIPTION
The is an alpha release, built on top of [OpenTelemetry .NET Auto Instrumentation v0.4.0-beta.1](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v0.4.0-beta.1).