### PR TITLE
Add OTel headers to files with OTel roots

### DIFF
--- a/build/docker/alpine.dockerfile
+++ b/build/docker/alpine.dockerfile
@@ -19,7 +19,7 @@ ENV gRPC_PluginFullPath=/usr/bin/grpc_csharp_plugin
 # Install older sdks using the install script
 RUN curl -sSL https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh \
     && echo "SHA256: $(sha256sum dotnet-install.sh)" \
-    && echo "2c51739e843231e9829a777fc6038e50b31d420e12a593edb9e858d3587ea361  dotnet-install.sh" | sha256sum -c \
+    && echo "3d5a87bc29fb96e8dac8c2f88d95ff619c3a921903b4c9ff720e07ca0906d55e  dotnet-install.sh" | sha256sum -c \
     && chmod +x ./dotnet-install.sh \
     && ./dotnet-install.sh -v 3.1.425 --install-dir /usr/share/dotnet --no-path \
     && rm dotnet-install.sh

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/EnvironmentHelper.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/EnvironmentHelper.cs
@@ -14,6 +14,22 @@
 // limitations under the License.
 // </copyright>
 
+// <copyright file="EnvironmentHelper.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/EnvironmentTools.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/EnvironmentTools.cs
@@ -14,6 +14,22 @@
 // limitations under the License.
 // </copyright>
 
+// <copyright file="EnvironmentTools.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
 using System;
 using System.IO;
 using System.Linq;

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/HealthzHelper.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/HealthzHelper.cs
@@ -14,6 +14,22 @@
 // limitations under the License.
 // </copyright>
 
+// <copyright file="HealthzHelper.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
 using System;
 using System.Net;
 using System.Net.Http;

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/InstrumentedProcessHelper.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/InstrumentedProcessHelper.cs
@@ -14,6 +14,22 @@
 // limitations under the License.
 // </copyright>
 
+// <copyright file="InstrumentedProcessHelper.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
 using System;
 using System.Diagnostics;
 

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/LogSettings.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/LogSettings.cs
@@ -14,6 +14,22 @@
 // limitations under the License.
 // </copyright>
 
+// <copyright file="LogSettings.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
 namespace Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests.Helpers;
 
 public class LogSettings

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/MetricsSettings.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/MetricsSettings.cs
@@ -14,6 +14,22 @@
 // limitations under the License.
 // </copyright>
 
+// <copyright file="MetricsSettings.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
 namespace Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests.Helpers;
 
 public class MetricsSettings

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/MockLogsCollector.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/MockLogsCollector.cs
@@ -14,6 +14,22 @@
 // limitations under the License.
 // </copyright>
 
+// <copyright file="MockLogsCollector.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/MockMetricsCollector.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/MockMetricsCollector.cs
@@ -14,6 +14,22 @@
 // limitations under the License.
 // </copyright>
 
+// <copyright file="MockMetricsCollector.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/MockTracesCollector.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/MockTracesCollector.cs
@@ -14,6 +14,22 @@
 // limitations under the License.
 // </copyright>
 
+// <copyright file="MockTracesCollector.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/OutputHelper.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/OutputHelper.cs
@@ -14,6 +14,22 @@
 // limitations under the License.
 // </copyright>
 
+// <copyright file="OutputHelper.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
 using System;
 using Xunit.Abstractions;
 

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/ProcessHelper.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/ProcessHelper.cs
@@ -14,6 +14,22 @@
 // limitations under the License.
 // </copyright>
 
+// <copyright file="ProcessHelper.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
 using System;
 using System.Diagnostics;
 using System.Text;

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/TcpPortProvider.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/TcpPortProvider.cs
@@ -14,6 +14,22 @@
 // limitations under the License.
 // </copyright>
 
+// <copyright file="TcpPortProvider.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
 using System.Net;
 using System.Net.Sockets;
 

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/TestHelper.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/TestHelper.cs
@@ -14,6 +14,22 @@
 // limitations under the License.
 // </copyright>
 
+// <copyright file="TestHelper.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
 using System;
 using System.Diagnostics;
 using System.IO;

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/TestHttpListener.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/TestHttpListener.cs
@@ -14,6 +14,22 @@
 // limitations under the License.
 // </copyright>
 
+// <copyright file="TestHttpListener.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
 using System;
 using System.Net;
 using System.Text;

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/TestSettings.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/TestSettings.cs
@@ -14,6 +14,22 @@
 // limitations under the License.
 // </copyright>
 
+// <copyright file="TestSettings.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
 namespace Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests.Helpers;
 
 public class TestSettings

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/TracesSettings.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/TracesSettings.cs
@@ -14,6 +14,22 @@
 // limitations under the License.
 // </copyright>
 
+// <copyright file="TracesSettings.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
 namespace Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests.Helpers;
 
 public class TracesSettings

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/SmokeTests.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/SmokeTests.cs
@@ -14,6 +14,22 @@
 // limitations under the License.
 // </copyright>
 
+// <copyright file="SmokeTests.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
 using System;
 using System.Threading.Tasks;
 using Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests.Helpers;


### PR DESCRIPTION
Add both Splunk and OTel license headers to files that originate from OTel repository.