### PR TITLE
Add injection of the splunk distro version

### DIFF
--- a/src/Splunk.OpenTelemetry.AutoInstrumentation.Plugin/ResourceInjector.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation.Plugin/ResourceInjector.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ResourceNameInjector.cs" company="Splunk Inc.">
+﻿// <copyright file="ResourceInjector.cs" company="Splunk Inc.">
 // Copyright Splunk Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation.Plugin/ResourceInjector.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation.Plugin/ResourceInjector.cs
@@ -21,9 +21,9 @@ using System.Linq;
 namespace Splunk.OpenTelemetry.AutoInstrumentation.Plugin
 {
     /// <summary>
-    /// Class providing injection of splunk distribution version.
+    /// Class providing injection of splunk resources.
     /// </summary>
-    public static class ResourceNameInjector
+    public static class ResourceInjector
     {
         private const string ResourceEnvVarKey = "OTEL_RESOURCE_ATTRIBUTES";
         private const string SplunkDistroVersionKey = "splunk.distro.version";
@@ -33,7 +33,7 @@ namespace Splunk.OpenTelemetry.AutoInstrumentation.Plugin
         /// <summary>
         /// Adds splunk plunk distribution version to the resources.
         /// </summary>
-        public static void AddSplunkResourceName()
+        public static void InjectSplunkDistributionVersion()
         {
             const string splunkDistroVersion = "v0.0.1-alpha.2";
 

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation.Plugin/ResourceNameInjector.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation.Plugin/ResourceNameInjector.cs
@@ -1,0 +1,76 @@
+﻿// <copyright file="ResourceNameInjector.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Plugin
+{
+    /// <summary>
+    /// Class providing injection of splunk distribution version.
+    /// </summary>
+    public static class ResourceNameInjector
+    {
+        private const string ResourceEnvVarKey = "OTEL_RESOURCE_ATTRIBUTES";
+        private const string SplunkDistroVersionKey = "splunk.distro.version";
+        private const char AttributeListSplitter = ',';
+        private const char AttributeKeyValueSplitter = '=';
+
+        /// <summary>
+        /// Adds splunk plunk distribution version to the resources.
+        /// </summary>
+        public static void AddSplunkResourceName()
+        {
+            const string splunkDistroVersion = "v0.0.1-alpha.2";
+
+            var resourcesEnvVarValue = Environment.GetEnvironmentVariable(ResourceEnvVarKey);
+            if (resourcesEnvVarValue == null)
+            {
+                Environment.SetEnvironmentVariable(ResourceEnvVarKey, $"{SplunkDistroVersionKey}{AttributeKeyValueSplitter}{splunkDistroVersion}");
+                return;
+            }
+
+            Dictionary<string, string> values;
+
+            try
+            {
+                values = resourcesEnvVarValue.Split(AttributeListSplitter)
+                    .ToDictionary(
+                        s => s.Split(AttributeKeyValueSplitter)[0],
+                        s => s.Split(AttributeKeyValueSplitter)[1]);
+            }
+            catch
+            {
+                // TODO: LOG ERROR
+                return;
+            }
+
+            if (values.ContainsKey(SplunkDistroVersionKey))
+            {
+                return;
+            }
+
+            values[SplunkDistroVersionKey] = splunkDistroVersion;
+
+            resourcesEnvVarValue = string.Join(
+                AttributeListSplitter.ToString(),
+                values.Select(keyValuePair => $"{keyValuePair.Key}{AttributeKeyValueSplitter}{keyValuePair.Value}"));
+
+            Environment.SetEnvironmentVariable(ResourceEnvVarKey, resourcesEnvVarValue);
+        }
+    }
+}

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation.Plugin/Traces.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation.Plugin/Traces.cs
@@ -30,7 +30,7 @@ public class Traces
     /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
     public TracerProviderBuilder ConfigureTracerProvider(TracerProviderBuilder builder)
     {
-        ResourceNameInjector.AddSplunkResourceName();
+        ResourceInjector.InjectSplunkDistributionVersion();
         return builder;
     }
 }

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation.Plugin/Traces.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation.Plugin/Traces.cs
@@ -30,6 +30,7 @@ public class Traces
     /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
     public TracerProviderBuilder ConfigureTracerProvider(TracerProviderBuilder builder)
     {
+        ResourceNameInjector.AddSplunkResourceName();
         return builder;
     }
 }


### PR DESCRIPTION
**Why**

We want splunk distro versions to be set in the resources.

**What**

Add injection of splunk distro version in the Traces plugin. This can be a temporary solution before we have extension for ResourceBuilder on the otel side.

**Tests**

Manual tests