### PR TITLE
Integration tests infrastructure from upstream

### DIFF
--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/CollectorResponseHelper.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/CollectorResponseHelper.cs
@@ -1,0 +1,96 @@
+// <copyright file="CollectorResponseHelper.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+// <copyright file="CollectorResponseHelper.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#nullable disable
+
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Google.Protobuf;
+
+#if NET6_0_OR_GREATER
+using Microsoft.AspNetCore.Http;
+#endif
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests.Helpers;
+
+internal static class CollectorResponseHelper
+{
+#if NETFRAMEWORK
+    public static void GenerateEmptyProtobufResponse<T>(this HttpListenerContext ctx)
+        where T : IMessage, new()
+    {
+        // NOTE: HttpStreamRequest doesn't support Transfer-Encoding: Chunked
+        // (Setting content-length avoids that)
+        ctx.Response.ContentType = "application/x-protobuf";
+        ctx.Response.StatusCode = (int)HttpStatusCode.OK;
+        var responseMessage = new T();
+        ctx.Response.ContentLength64 = responseMessage.CalculateSize();
+        responseMessage.WriteTo(ctx.Response.OutputStream);
+        ctx.Response.Close();
+    }
+
+    public static void GenerateEmptyJsonResponse(this HttpListenerContext ctx)
+    {
+        // NOTE: HttpStreamRequest doesn't support Transfer-Encoding: Chunked
+        // (Setting content-length avoids that)
+        ctx.Response.ContentType = "application/json";
+        var buffer = Encoding.UTF8.GetBytes("{}");
+        ctx.Response.ContentLength64 = buffer.LongLength;
+        ctx.Response.OutputStream.Write(buffer, 0, buffer.Length);
+        ctx.Response.Close();
+    }
+#endif
+
+#if NET6_0_OR_GREATER
+    public static async Task GenerateEmptyProtobufResponseAsync<T>(this HttpContext ctx)
+        where T : IMessage, new()
+    {
+        ctx.Response.ContentType = "application/x-protobuf";
+        ctx.Response.StatusCode = (int)HttpStatusCode.OK;
+        var responseMessage = new T();
+        ctx.Response.ContentLength = responseMessage.CalculateSize();
+
+        using var outMemory = new MemoryStream();
+        responseMessage.WriteTo(outMemory);
+        await ctx.Response.Body.WriteAsync(outMemory.GetBuffer(), 0, (int)outMemory.Length);
+        await ctx.Response.CompleteAsync();
+    }
+
+    public static async Task GenerateEmptyJsonResponseAsync(this HttpContext ctx)
+    {
+        ctx.Response.ContentType = "application/json";
+        await ctx.Response.WriteAsync("{}");
+    }
+#endif
+}

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/Compatibility/DictionaryExtensions.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/Compatibility/DictionaryExtensions.cs
@@ -1,0 +1,113 @@
+// <copyright file="DictionaryExtensions.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+// <copyright file="DictionaryExtensions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#nullable disable
+
+#if NETFRAMEWORK
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests.Helpers.Compatibility;
+
+public static class DictionaryExtensions
+{
+    public static TValue GetValueOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key)
+    {
+        if (dictionary == null)
+        {
+            throw new ArgumentNullException(nameof(dictionary));
+        }
+
+        return dictionary.TryGetValue(key, out var value)
+                    ? value
+                    : default;
+    }
+
+    public static TValue GetValueOrDefault<TValue>(this IDictionary dictionary, object key)
+    {
+        if (dictionary == null)
+        {
+            throw new ArgumentNullException(nameof(dictionary));
+        }
+
+        return dictionary.TryGetValue(key, out TValue value)
+                    ? value
+                    : default;
+    }
+
+    public static bool TryGetValue<TValue>(this IDictionary dictionary, object key, out TValue value)
+    {
+        if (dictionary == null)
+        {
+            throw new ArgumentNullException(nameof(dictionary));
+        }
+
+        object valueObj;
+
+        try
+        {
+            // per its contract, IDictionary.Item[] should return null instead of throwing an exception
+            // if a key is not found, but let's use try/catch to be defensive against misbehaving implementations
+            valueObj = dictionary[key];
+        }
+        catch
+        {
+            valueObj = null;
+        }
+
+        switch (valueObj)
+        {
+            case TValue valueTyped:
+                value = valueTyped;
+                return true;
+            case IConvertible convertible:
+                value = (TValue)convertible.ToType(typeof(TValue), provider: null);
+                return true;
+            default:
+                value = default;
+                return false;
+        }
+    }
+
+    public static bool IsEmpty<TKey, TValue>(this IDictionary<TKey, TValue> dictionary)
+    {
+        if (dictionary is ConcurrentDictionary<TKey, TValue> concurrentDictionary)
+        {
+            return concurrentDictionary.IsEmpty;
+        }
+
+        return dictionary.Count == 0;
+    }
+}
+#endif

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/DockerNetworkHelper.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/DockerNetworkHelper.cs
@@ -1,0 +1,99 @@
+// <copyright file="DockerNetworkHelper.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+// <copyright file="DockerNetworkHelper.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Docker.DotNet;
+using Docker.DotNet.Models;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests.Helpers;
+
+/// <summary>
+/// Helper to call Docker network API
+/// </summary>
+internal static class DockerNetworkHelper
+{
+    public const string IntegrationTestsNetworkName = "integration-tests";
+    public const string IntegrationTestsGateway = "10.1.1.1";
+
+    /// <summary>
+    /// Creates a new Docker network with fixed name and gateway.
+    /// if named network exists with specified fixed gateway address, gets the existing one.
+    /// </summary>
+    /// <returns>Docker network ID</returns>
+    internal static async Task<string> SetupIntegrationTestsNetworkAsync()
+    {
+        var client = new DockerClientConfiguration().CreateClient();
+        var networks = await client.Networks.ListNetworksAsync();
+        var network = networks.FirstOrDefault(x => x.Name == IntegrationTestsNetworkName);
+
+        if (network != null)
+        {
+            if (network.IPAM.Config[0].Gateway == IntegrationTestsGateway)
+            {
+                return network.ID;
+            }
+            else
+            {
+                await client.Networks.DeleteNetworkAsync(network.ID);
+            }
+        }
+
+        var networkParams = new NetworksCreateParameters()
+        {
+            Name = IntegrationTestsNetworkName,
+            Driver = "nat",
+            IPAM = new IPAM()
+            {
+                Config = new List<IPAMConfig>()
+            }
+        };
+
+        networkParams.IPAM.Config.Add(new IPAMConfig()
+        {
+            Gateway = IntegrationTestsGateway,
+            Subnet = "10.1.1.0/24"
+        });
+
+        var result = await client.Networks.CreateNetworkAsync(networkParams);
+        if (string.IsNullOrWhiteSpace(result.ID))
+        {
+            throw new Exception("Could not create docker network");
+        }
+
+        return result.ID;
+    }
+}

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/EnvironmentHelper.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/EnvironmentHelper.cs
@@ -30,6 +30,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -44,41 +46,43 @@ namespace Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests.Helpers;
 public class EnvironmentHelper
 {
     private static readonly string RuntimeFrameworkDescription = RuntimeInformation.FrameworkDescription.ToLower();
-    private static string? _nukeOutputLocation;
+    private static string _nukeOutputLocation;
 
     private readonly ITestOutputHelper _output;
-    private readonly int? _major;
-    private readonly int? _minor;
-    private readonly string? _patch;
+    private readonly int _major;
+    private readonly int _minor;
+    private readonly string _patch = null;
 
     private readonly string _appNamePrepend;
-    private readonly bool? _isCoreClr;
+    private readonly string _runtime;
+    private readonly bool _isCoreClr;
     private readonly string _testApplicationDirectory;
+    private readonly TargetFrameworkAttribute _targetFramework;
 
-    private string? _integrationsFileLocation;
-    private string? _profilerFileLocation;
+    private string _integrationsFileLocation;
+    private string _profilerFileLocation;
 
     public EnvironmentHelper(
         string testApplicationName,
         Type anchorType,
         ITestOutputHelper output,
-        string? testApplicationDirectory = null,
+        string testApplicationDirectory = null,
         bool prependTestApplicationToAppName = true)
     {
         TestApplicationName = testApplicationName;
         _testApplicationDirectory = testApplicationDirectory ?? Path.Combine("test", "test-applications", "integrations");
-        var targetFramework = Assembly.GetAssembly(anchorType)?.GetCustomAttribute<TargetFrameworkAttribute>();
+        _targetFramework = Assembly.GetAssembly(anchorType).GetCustomAttribute<TargetFrameworkAttribute>();
         _output = output;
 
-        var parts = targetFramework?.FrameworkName.Split(',');
-        var runtime = parts?[0];
-        _isCoreClr = runtime?.Equals(EnvironmentTools.CoreFramework);
+        var parts = _targetFramework.FrameworkName.Split(',');
+        _runtime = parts[0];
+        _isCoreClr = _runtime.Equals(EnvironmentTools.CoreFramework);
 
-        var versionParts = parts?[1].Replace("Version=v", string.Empty).Split('.');
-        _major = int.Parse(versionParts == null ? string.Empty : versionParts[0]);
-        _minor = int.Parse(versionParts == null ? string.Empty : versionParts[1]);
+        var versionParts = parts[1].Replace("Version=v", string.Empty).Split('.');
+        _major = int.Parse(versionParts[0]);
+        _minor = int.Parse(versionParts[1]);
 
-        if (versionParts?.Length == 3)
+        if (versionParts.Length == 3)
         {
             _patch = versionParts[2];
         }
@@ -86,11 +90,13 @@ public class EnvironmentHelper
         _appNamePrepend = prependTestApplicationToAppName
             ? "TestApplication."
             : string.Empty;
+
+        SetDefaultEnvironmentVariables();
     }
 
     public bool DebugModeEnabled { get; set; } = true;
 
-    public Dictionary<string, string> CustomEnvironmentVariables { get; set; } = new();
+    public Dictionary<string, string> CustomEnvironmentVariables { get; set; } = new Dictionary<string, string>();
 
     public string TestApplicationName { get; }
 
@@ -118,80 +124,17 @@ public class EnvironmentHelper
         throw new Exception($"Unable to find Nuke output at: {nukeOutputPath}. Ensure Nuke has run first.");
     }
 
-    public void SetEnvironmentVariables(
-        TestSettings testSettings,
-        StringDictionary environmentVariables,
-        string processToProfile)
+    public static bool IsRunningOnCI()
     {
-        string profilerPath = GetProfilerPath();
+        // https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
+        // Github sets CI environment variable
 
-        if (IsCoreClr())
-        {
-            // enableStartupHook should be true by default, and the parameter should only be set
-            // to false when testing the case that instrumentation should not be available.
-            if (testSettings.EnableStartupHook)
-            {
-                environmentVariables["DOTNET_STARTUP_HOOKS"] = GetStartupHookOutputPath();
-                environmentVariables["DOTNET_SHARED_STORE"] = GetSharedStorePath();
-                environmentVariables["DOTNET_ADDITIONAL_DEPS"] = GetAdditionalDepsPath();
-            }
+        string env = Environment.GetEnvironmentVariable("CI");
+        return !string.IsNullOrEmpty(env);
+    }
 
-            if (testSettings.EnableClrProfiler)
-            {
-                environmentVariables["CORECLR_ENABLE_PROFILING"] = "1";
-                environmentVariables["CORECLR_PROFILER"] = EnvironmentTools.ProfilerClsId;
-                environmentVariables["CORECLR_PROFILER_PATH"] = profilerPath;
-            }
-        }
-        else
-        {
-            if (testSettings.EnableClrProfiler)
-            {
-                environmentVariables["COR_ENABLE_PROFILING"] = "1";
-                environmentVariables["COR_PROFILER"] = EnvironmentTools.ProfilerClsId;
-                environmentVariables["COR_PROFILER_PATH"] = profilerPath;
-            }
-        }
-
-        if (DebugModeEnabled)
-        {
-            environmentVariables["OTEL_DOTNET_AUTO_DEBUG"] = "1";
-            var solutionDirectory = EnvironmentTools.GetSolutionDirectory() ?? string.Empty;
-            environmentVariables["OTEL_DOTNET_AUTO_LOG_DIRECTORY"] = Path.Combine(solutionDirectory, "build_data", "profiler-logs");
-        }
-
-        if (!string.IsNullOrEmpty(processToProfile))
-        {
-            environmentVariables["OTEL_DOTNET_AUTO_INCLUDE_PROCESSES"] = Path.GetFileName(processToProfile);
-        }
-
-        environmentVariables["OTEL_DOTNET_AUTO_HOME"] = GetNukeBuildOutput();
-
-        environmentVariables["OTEL_DOTNET_AUTO_INTEGRATIONS_FILE"] = Environment.GetEnvironmentVariable("OTEL_DOTNET_AUTO_INTEGRATIONS_FILE") ?? GetIntegrationsPath();
-
-        if (testSettings.TracesSettings != null)
-        {
-            environmentVariables["OTEL_TRACES_EXPORTER"] = testSettings.TracesSettings.Exporter;
-            environmentVariables["OTEL_EXPORTER_OTLP_ENDPOINT"] = $"http://localhost:{testSettings.TracesSettings.Port}";
-        }
-
-        if (testSettings.MetricsSettings != null)
-        {
-            environmentVariables["OTEL_METRICS_EXPORTER"] = testSettings.MetricsSettings.Exporter;
-            environmentVariables["OTEL_EXPORTER_OTLP_ENDPOINT"] = $"http://localhost:{testSettings.MetricsSettings.Port}";
-        }
-
-        if (testSettings.LogSettings != null)
-        {
-            environmentVariables["OTEL_LOGS_EXPORTER"] = testSettings.LogSettings.Exporter;
-            environmentVariables["OTEL_EXPORTER_OTLP_ENDPOINT"] = $"http://localhost:{testSettings.LogSettings.Port}";
-        }
-
-        // for ASP.NET Core test applications, set the server's port
-        environmentVariables["ASPNETCORE_URLS"] = $"http://127.0.0.1:{testSettings.AspNetCorePort}/";
-
-        environmentVariables["OTEL_DOTNET_AUTO_TRACES_ADDITIONAL_SOURCES"] = "TestApplication.*";
-
+    public void SetEnvironmentVariables(StringDictionary environmentVariables)
+    {
         foreach (var key in CustomEnvironmentVariables.Keys)
         {
             environmentVariables[key] = CustomEnvironmentVariables[key];
@@ -205,7 +148,7 @@ public class EnvironmentHelper
             return _profilerFileLocation;
         }
 
-        string extension = EnvironmentTools.GetOs() switch
+        string extension = EnvironmentTools.GetOS() switch
         {
             "win" => "dll",
             "linux" => "so",
@@ -213,16 +156,16 @@ public class EnvironmentHelper
             _ => throw new PlatformNotSupportedException()
         };
 
-        var fileName = $"OpenTelemetry.AutoInstrumentation.Native.{extension}";
-        var nukeOutput = GetNukeBuildOutput();
-        var profilerPath = EnvironmentTools.IsWindows()
+        string fileName = $"OpenTelemetry.AutoInstrumentation.Native.{extension}";
+        string nukeOutput = GetNukeBuildOutput();
+        string profilerPath = EnvironmentTools.IsWindows()
             ? Path.Combine(nukeOutput, $"win-{EnvironmentTools.GetPlatform().ToLower()}", fileName)
             : Path.Combine(nukeOutput, fileName);
 
         if (File.Exists(profilerPath))
         {
             _profilerFileLocation = profilerPath;
-            _output.WriteLine($"Found profiler at {_profilerFileLocation}.");
+            _output?.WriteLine($"Found profiler at {_profilerFileLocation}.");
             return _profilerFileLocation;
         }
 
@@ -236,13 +179,13 @@ public class EnvironmentHelper
             return _integrationsFileLocation;
         }
 
-        var fileName = "integrations.json";
-        var integrationsPath = Path.Combine(GetNukeBuildOutput(), fileName);
+        string fileName = $"integrations.json";
+        string integrationsPath = Path.Combine(GetNukeBuildOutput(), fileName);
 
         if (File.Exists(integrationsPath))
         {
             _integrationsFileLocation = integrationsPath;
-            _output.WriteLine($"Found integrations at {_profilerFileLocation}.");
+            _output?.WriteLine($"Found integrations at {_profilerFileLocation}.");
             return _integrationsFileLocation;
         }
 
@@ -251,7 +194,7 @@ public class EnvironmentHelper
 
     public string GetTestApplicationPath(string packageVersion = "", string framework = "")
     {
-        var extension = "exe";
+        string extension = "exe";
 
         if (IsCoreClr() || _testApplicationDirectory.Contains("aspnet"))
         {
@@ -293,7 +236,7 @@ public class EnvironmentHelper
     {
         var solutionDirectory = EnvironmentTools.GetSolutionDirectory();
         var projectDir = Path.Combine(
-            solutionDirectory ?? string.Empty,
+            solutionDirectory,
             _testApplicationDirectory,
             $"{FullTestApplicationName}");
         return projectDir;
@@ -324,14 +267,9 @@ public class EnvironmentHelper
 
     public string GetTargetFramework()
     {
-        if (_isCoreClr.HasValue && _isCoreClr.Value)
+        if (_isCoreClr)
         {
-            if (_major >= 5)
-            {
-                return $"net{_major}.{_minor}";
-            }
-
-            return $"netcoreapp{_major}.{_minor}";
+            return $"net{_major}.{_minor}";
         }
 
         return $"net{_major}{_minor}{_patch ?? string.Empty}";
@@ -339,7 +277,7 @@ public class EnvironmentHelper
 
     private static string GetStartupHookOutputPath()
     {
-        var startupHookOutputPath = Path.Combine(
+        string startupHookOutputPath = Path.Combine(
             GetNukeBuildOutput(),
             "net",
             "OpenTelemetry.AutoInstrumentation.StartupHook.dll");
@@ -349,7 +287,7 @@ public class EnvironmentHelper
 
     private static string GetSharedStorePath()
     {
-        var storePath = Path.Combine(
+        string storePath = Path.Combine(
             GetNukeBuildOutput(),
             "store");
 
@@ -358,10 +296,39 @@ public class EnvironmentHelper
 
     private static string GetAdditionalDepsPath()
     {
-        var additionalDeps = Path.Combine(
+        string additionalDeps = Path.Combine(
             GetNukeBuildOutput(),
             "AdditionalDeps");
 
         return additionalDeps;
+    }
+
+    private void SetDefaultEnvironmentVariables()
+    {
+        string profilerPath = GetProfilerPath();
+
+        CustomEnvironmentVariables["DOTNET_STARTUP_HOOKS"] = GetStartupHookOutputPath();
+        CustomEnvironmentVariables["DOTNET_SHARED_STORE"] = GetSharedStorePath();
+        CustomEnvironmentVariables["DOTNET_ADDITIONAL_DEPS"] = GetAdditionalDepsPath();
+
+        // call TestHelper.EnableBytecodeInstrumentation() to enable CoreCLR Profiler when bytecode instrumentation is needed
+        // it is not enabled by default to make sure that the instrumentations that do not require CoreCLR Profiler are working without it
+        CustomEnvironmentVariables["CORECLR_PROFILER"] = EnvironmentTools.ProfilerClsId;
+        CustomEnvironmentVariables["CORECLR_PROFILER_PATH"] = profilerPath;
+
+        CustomEnvironmentVariables["COR_ENABLE_PROFILING"] = "1";
+        CustomEnvironmentVariables["COR_PROFILER"] = EnvironmentTools.ProfilerClsId;
+        CustomEnvironmentVariables["COR_PROFILER_PATH"] = profilerPath;
+
+        CustomEnvironmentVariables["OTEL_DOTNET_AUTO_DEBUG"] = "1";
+        CustomEnvironmentVariables["OTEL_DOTNET_AUTO_LOG_DIRECTORY"] = Path.Combine(EnvironmentTools.GetSolutionDirectory(), "build_data", "profiler-logs");
+        CustomEnvironmentVariables["OTEL_DOTNET_AUTO_HOME"] = GetNukeBuildOutput();
+        CustomEnvironmentVariables["OTEL_DOTNET_AUTO_INTEGRATIONS_FILE"] = Environment.GetEnvironmentVariable("OTEL_DOTNET_AUTO_INTEGRATIONS_FILE") ?? GetIntegrationsPath();
+        CustomEnvironmentVariables["OTEL_DOTNET_AUTO_TRACES_ADDITIONAL_SOURCES"] = "TestApplication.*";
+
+        // exporters are disabled by default in order not to have errors in the logs
+        CustomEnvironmentVariables["OTEL_TRACES_EXPORTER"] = "none";
+        CustomEnvironmentVariables["OTEL_METRICS_EXPORTER"] = "none";
+        CustomEnvironmentVariables["OTEL_LOGS_EXPORTER"] = "none";
     }
 }

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/GacEntry.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/GacEntry.cs
@@ -1,4 +1,4 @@
-// <copyright file="MetricsSettings.cs" company="Splunk Inc.">
+// <copyright file="GacEntry.cs" company="Splunk Inc.">
 // Copyright Splunk Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +14,7 @@
 // limitations under the License.
 // </copyright>
 
-// <copyright file="MetricsSettings.cs" company="OpenTelemetry Authors">
+// <copyright file="GacEntry.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,11 +30,28 @@
 // limitations under the License.
 // </copyright>
 
+#nullable disable
+
+#if NETFRAMEWORK
+using System;
+using System.EnterpriseServices.Internal;
+
 namespace Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests.Helpers;
 
-public class MetricsSettings
+public class GacEntry : IDisposable
 {
-    public string Exporter => "otlp";
+    private readonly string _assemblyPath;
+    private readonly Publish _publish = new Publish();
 
-    public int Port { get; set; }
+    public GacEntry(string assemblyPath)
+    {
+        _assemblyPath = assemblyPath;
+        _publish.GacInstall(assemblyPath);
+    }
+
+    public void Dispose()
+    {
+        _publish.GacRemove(_assemblyPath);
+    }
 }
+#endif

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/InstrumentedProcessHelper.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/InstrumentedProcessHelper.cs
@@ -30,6 +30,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable disable
+
 using System;
 using System.Diagnostics;
 
@@ -37,11 +39,7 @@ namespace Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests.Helpers;
 
 public class InstrumentedProcessHelper
 {
-    public static Process? StartInstrumentedProcess(
-        string executable,
-        EnvironmentHelper environmentHelper,
-        string? arguments,
-        TestSettings testSettings)
+    public static Process Start(string executable, string arguments, EnvironmentHelper environmentHelper)
     {
         if (environmentHelper == null)
         {
@@ -50,7 +48,7 @@ public class InstrumentedProcessHelper
 
         var startInfo = new ProcessStartInfo(executable, arguments ?? string.Empty);
 
-        environmentHelper.SetEnvironmentVariables(testSettings, startInfo.EnvironmentVariables, executable);
+        environmentHelper.SetEnvironmentVariables(startInfo.EnvironmentVariables);
 
         startInfo.UseShellExecute = false;
         startInfo.CreateNoWindow = true;

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/MockZipkinCollector.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/MockZipkinCollector.cs
@@ -1,0 +1,358 @@
+// <copyright file="MockZipkinCollector.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+// <copyright file="MockZipkinCollector.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#nullable disable
+
+#if NETFRAMEWORK
+using System.Net;
+using Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests.Helpers.Compatibility;
+#else
+using Microsoft.AspNetCore.Http;
+#endif
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests.Helpers;
+
+public class MockZipkinCollector : IDisposable
+{
+    private readonly ITestOutputHelper _output;
+    private readonly TestHttpServer _listener;
+
+    private readonly BlockingCollection<ZSpanMock> _spans = new(100); // bounded to avoid memory leak
+    private readonly List<Expectation> _expectations = new();
+
+    public MockZipkinCollector(ITestOutputHelper output, string host = "localhost")
+    {
+        _output = output;
+#if NETFRAMEWORK
+        _listener = new TestHttpServer(output, HandleHttpRequests, host, "/api/v2/spans/");
+#else
+        _listener = new TestHttpServer(output, HandleHttpRequests, "/api/v2/spans");
+#endif
+    }
+
+    /// <summary>
+    /// Gets the TCP port that this collector is listening on.
+    /// </summary>
+    public int Port { get => _listener.Port; }
+
+    public void Dispose()
+    {
+        WriteOutput("Shutting down.");
+        _spans.Dispose();
+        _listener.Dispose();
+    }
+
+    public void Expect(Func<ZSpanMock, bool> predicate = null, string description = null)
+    {
+        predicate ??= x => true;
+        description ??= "<no description>";
+
+        _expectations.Add(new Expectation { Predicate = predicate, Description = description });
+    }
+
+    public void AssertExpectations(TimeSpan? timeout = null)
+    {
+        if (_expectations.Count == 0)
+        {
+            throw new InvalidOperationException("Expectations were not set");
+        }
+
+        var missingExpectations = new List<Expectation>(_expectations);
+        var expectationsMet = new List<ZSpanMock>();
+        var additionalEntries = new List<ZSpanMock>();
+
+        timeout ??= Timeout.Expectation;
+        var cts = new CancellationTokenSource();
+
+        try
+        {
+            cts.CancelAfter(timeout.Value);
+            foreach (var span in _spans.GetConsumingEnumerable(cts.Token))
+            {
+                var found = false;
+                for (var i = missingExpectations.Count - 1; i >= 0; i--)
+                {
+                    if (!missingExpectations[i].Predicate(span))
+                    {
+                        continue;
+                    }
+
+                    expectationsMet.Add(span);
+                    missingExpectations.RemoveAt(i);
+                    found = true;
+                    break;
+                }
+
+                if (!found)
+                {
+                    additionalEntries.Add(span);
+                    continue;
+                }
+
+                if (missingExpectations.Count == 0)
+                {
+                    return;
+                }
+            }
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            // CancelAfter called with non-positive value
+            FailExpectations(missingExpectations, expectationsMet, additionalEntries);
+        }
+        catch (OperationCanceledException)
+        {
+            // timeout
+            FailExpectations(missingExpectations, expectationsMet, additionalEntries);
+        }
+    }
+
+    private static void FailExpectations(
+        List<Expectation> missingExpectations,
+        List<ZSpanMock> expectationsMet,
+        List<ZSpanMock> additionalEntries)
+    {
+        var message = new StringBuilder();
+        message.AppendLine();
+
+        message.AppendLine("Missing expectations:");
+        foreach (var logline in missingExpectations)
+        {
+            message.AppendLine($"  - \"{logline.Description}\"");
+        }
+
+        message.AppendLine("Entries meeting expectations:");
+        foreach (var logline in expectationsMet)
+        {
+            message.AppendLine($"    \"{logline}\"");
+        }
+
+        message.AppendLine("Additional entries:");
+        foreach (var logline in additionalEntries)
+        {
+            message.AppendLine($"  + \"{logline}\"");
+        }
+
+        Assert.Fail(message.ToString());
+    }
+
+#if NETFRAMEWORK
+    private void HandleHttpRequests(HttpListenerContext ctx)
+    {
+        HandleJsonStream(ctx.Request.InputStream);
+
+        ctx.GenerateEmptyJsonResponse();
+    }
+#else
+    private async Task HandleHttpRequests(HttpContext ctx)
+    {
+        using var bodyStream = await ctx.ReadBodyToMemoryAsync();
+        HandleJsonStream(bodyStream);
+
+        await ctx.GenerateEmptyJsonResponseAsync();
+    }
+#endif
+
+    private void HandleJsonStream(Stream bodyStream)
+    {
+        using var reader = new StreamReader(bodyStream);
+        var zspans = JsonConvert.DeserializeObject<List<ZSpanMock>>(reader.ReadToEnd());
+        foreach (var span in zspans ?? Enumerable.Empty<ZSpanMock>())
+        {
+            _spans.Add(span);
+        }
+    }
+
+    private void WriteOutput(string msg)
+    {
+        const string name = nameof(MockZipkinCollector);
+        _output.WriteLine($"[{name}]: {msg}");
+    }
+
+    [DebuggerDisplay("TraceId={TraceId}, SpanId={SpanId}, Service={Service}, Name={Name}")]
+    public class ZSpanMock
+    {
+        [JsonExtensionData]
+        private Dictionary<string, JToken> _zipkinData;
+
+        public ZSpanMock()
+        {
+            _zipkinData = new Dictionary<string, JToken>();
+        }
+
+        public string TraceId
+        {
+            get => _zipkinData["traceId"].ToString();
+        }
+
+        public ulong SpanId
+        {
+            get => Convert.ToUInt64(_zipkinData["id"].ToString(), 16);
+        }
+
+        public string Name { get; set; }
+
+        public string Service
+        {
+            get => _zipkinData["localEndpoint"]["serviceName"].ToString();
+        }
+
+        public string Library { get; set; }
+
+        public ActivityKind Kind
+        {
+            get
+            {
+                if (_zipkinData.TryGetValue("kind", out var value))
+                {
+                    return (ActivityKind)Enum.Parse(typeof(ActivityKind), value.ToString(), true);
+                }
+
+                return ActivityKind.Internal;
+            }
+        }
+
+        public long Start
+        {
+            get => Convert.ToInt64(_zipkinData["timestamp"].ToString());
+        }
+
+        public long Duration { get; set; }
+
+        public ulong? ParentId
+        {
+            get
+            {
+                _zipkinData.TryGetValue("parentId", out JToken parentId);
+                return parentId == null ? null : Convert.ToUInt64(parentId.ToString(), 16);
+            }
+        }
+
+        public byte Error { get; set; }
+
+        public Dictionary<string, string> Tags { get; set; }
+
+        public Dictionary<DateTimeOffset, Dictionary<string, object>> Logs
+        {
+            get
+            {
+                var logs = new Dictionary<DateTimeOffset, Dictionary<string, object>>();
+
+                if (_zipkinData.TryGetValue("annotations", out JToken annotations))
+                {
+                    foreach (var item in annotations.ToObject<List<Dictionary<string, object>>>())
+                    {
+                        DateTimeOffset timestamp = ((long)item["timestamp"]).UnixMicrosecondsToDateTimeOffset();
+                        item.Remove("timestamp");
+                        logs[timestamp] = item;
+                    }
+                }
+
+                return logs;
+            }
+        }
+
+        public Dictionary<string, double> Metrics { get; set; }
+
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"TraceId: {TraceId}");
+            sb.AppendLine($"ParentId: {ParentId}");
+            sb.AppendLine($"SpanId: {SpanId}");
+            sb.AppendLine($"Service: {Service}");
+            sb.AppendLine($"Name: {Name}");
+            sb.AppendLine($"Library: {Library}");
+            sb.AppendLine($"Kind: {Kind}");
+            sb.AppendLine($"Start: {Start}");
+            sb.AppendLine($"Duration: {Duration}");
+            sb.AppendLine($"Error: {Error}");
+            sb.AppendLine("Tags:");
+
+            if (Tags?.Count > 0)
+            {
+                foreach (var kv in Tags)
+                {
+                    sb.Append($"\t{kv.Key}:{kv.Value}\n");
+                }
+            }
+
+            sb.AppendLine("Logs:");
+            foreach (var e in Logs)
+            {
+                sb.Append($"\t{e.Key}:\n");
+                foreach (var kv in e.Value)
+                {
+                    sb.Append($"\t\t{kv.Key}:{kv.Value}\n");
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        [OnDeserialized]
+        private void OnDeserialized(StreamingContext context)
+        {
+            Library = Tags.GetValueOrDefault("otel.library.name");
+
+            var error = Tags.GetValueOrDefault("error") ?? "false";
+            Error = (byte)(error.ToLowerInvariant().Equals("true") ? 1 : 0);
+
+            var spanKind = _zipkinData.GetValueOrDefault("kind")?.ToString();
+            if (spanKind != null)
+            {
+                Tags["span.kind"] = spanKind.ToLowerInvariant();
+            }
+        }
+    }
+
+    private class Expectation
+    {
+        public Func<ZSpanMock, bool> Predicate { get; set; }
+
+        public string Description { get; set; }
+    }
+}

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/OtlpResourceExpector.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/OtlpResourceExpector.cs
@@ -1,0 +1,155 @@
+// <copyright file="OtlpResourceExpector.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+// <copyright file="OtlpResourceExpector.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using Google.Protobuf.Collections;
+using OpenTelemetry.Proto.Common.V1;
+using OpenTelemetry.Proto.Resource.V1;
+using Xunit;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests.Helpers;
+
+public class OtlpResourceExpector : IDisposable
+{
+    private readonly List<ResourceExpectation> _resourceExpectations = new();
+
+    private readonly ManualResetEvent _resourceAttributesEvent = new(false); // synchronizes access to _resourceAttributes
+    private RepeatedField<KeyValue> _resourceAttributes; // protobuf type
+
+    public void Dispose()
+    {
+        _resourceAttributesEvent.Dispose();
+    }
+
+    public void Collect(Resource resource)
+    {
+        // resource metrics are always the same. set them only once.
+        if (_resourceAttributes == null)
+        {
+            _resourceAttributes = resource.Attributes;
+            _resourceAttributesEvent.Set();
+        }
+    }
+
+    public void Expect(string key, string value)
+    {
+        _resourceExpectations.Add(new ResourceExpectation { Key = key, Value = value });
+    }
+
+    public void AssertExpectations(TimeSpan? timeout = null)
+    {
+        if (_resourceExpectations.Count == 0)
+        {
+            throw new InvalidOperationException("Expectations were not set");
+        }
+
+        timeout ??= Timeout.Expectation;
+
+        try
+        {
+            if (!_resourceAttributesEvent.WaitOne(timeout.Value))
+            {
+                FailResourceMetrics(_resourceExpectations, null);
+                return;
+            }
+
+            AssertResourceMetrics(_resourceExpectations, _resourceAttributes);
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            // WaitOne called with non-positive value
+            FailResourceMetrics(_resourceExpectations, null);
+        }
+    }
+
+    private static void AssertResourceMetrics(List<ResourceExpectation> resourceExpectations, RepeatedField<KeyValue> actualResourceAttributes)
+    {
+        var missingExpectations = new List<ResourceExpectation>(resourceExpectations);
+        foreach (var resourceAttribute in actualResourceAttributes)
+        {
+            for (int i = missingExpectations.Count - 1; i >= 0; i--)
+            {
+                if (resourceAttribute.Key != missingExpectations[i].Key)
+                {
+                    continue;
+                }
+
+                if (resourceAttribute.Value.StringValue != missingExpectations[i].Value)
+                {
+                    continue;
+                }
+
+                missingExpectations.RemoveAt(i);
+                break;
+            }
+        }
+
+        if (missingExpectations.Count > 0)
+        {
+            FailResourceMetrics(missingExpectations, actualResourceAttributes);
+        }
+    }
+
+    private static void FailResourceMetrics(List<ResourceExpectation> missingExpectations, RepeatedField<KeyValue> attributes)
+    {
+        attributes ??= new();
+
+        var message = new StringBuilder();
+        message.AppendLine();
+
+        message.AppendLine("Missing resource expectations:");
+        foreach (var expectation in missingExpectations)
+        {
+            message.AppendLine($"  - \"{expectation.Key}={expectation.Value}\"");
+        }
+
+        message.AppendLine("Actual resource attributes:");
+        foreach (var attribute in attributes)
+        {
+            message.AppendLine($"  + \"{attribute.Key}={attribute.Value.StringValue}\"");
+        }
+
+        Assert.Fail(message.ToString());
+    }
+
+    private class ResourceExpectation
+    {
+        public string Key { get; set; }
+
+        public string Value { get; set; }
+    }
+}

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/PowershellHelper.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/PowershellHelper.cs
@@ -1,4 +1,4 @@
-// <copyright file="LogSettings.cs" company="Splunk Inc.">
+// <copyright file="PowershellHelper.cs" company="Splunk Inc.">
 // Copyright Splunk Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +14,7 @@
 // limitations under the License.
 // </copyright>
 
-// <copyright file="LogSettings.cs" company="OpenTelemetry Authors">
+// <copyright file="PowershellHelper.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,11 +30,33 @@
 // limitations under the License.
 // </copyright>
 
+#nullable disable
+
+using System.Diagnostics;
+using Xunit.Abstractions;
+
 namespace Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests.Helpers;
 
-public class LogSettings
+public static class PowershellHelper
 {
-    public string Exporter => "otlp";
+    public static (string StandardOutput, string ErrorOutput) RunCommand(string psCommand, ITestOutputHelper outputHelper)
+    {
+        ProcessStartInfo startInfo = new ProcessStartInfo();
+        startInfo.FileName = @"powershell.exe";
+        startInfo.Arguments = $"& {psCommand}";
+        startInfo.RedirectStandardOutput = true;
+        startInfo.RedirectStandardError = true;
+        startInfo.UseShellExecute = false;
+        startInfo.CreateNoWindow = true;
+        startInfo.Verb = "runas";
 
-    public int Port { get; set; }
+        Process process = Process.Start(startInfo);
+        ProcessHelper helper = new ProcessHelper(process);
+        process.WaitForExit();
+
+        outputHelper.WriteLine($"PS> {psCommand}");
+        outputHelper.WriteResult(helper);
+
+        return (helper.StandardOutput, helper.ErrorOutput);
+    }
 }

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/RuntimeHelper.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/RuntimeHelper.cs
@@ -1,0 +1,92 @@
+// <copyright file="RuntimeHelper.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+// <copyright file="RuntimeHelper.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#nullable disable
+
+#if NETFRAMEWORK
+
+using Microsoft.Win32;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests.Helpers;
+
+internal static class RuntimeHelper
+{
+    // https://learn.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed
+    public static string GetRuntimeVersion()
+    {
+        const string subkey = @"SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\";
+
+        using (var ndpKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32).OpenSubKey(subkey))
+        {
+            if (ndpKey != null && ndpKey.GetValue("Release") != null)
+            {
+                return CheckFor45PlusVersion((int)ndpKey.GetValue("Release"));
+            }
+
+            return null;
+        }
+
+        // Checking the version using >= enables forward compatibility.
+        static string CheckFor45PlusVersion(int releaseKey)
+        {
+#pragma warning disable SA1503 // Braces should not be omitted
+            if (releaseKey >= 533320)
+                return "4.8.1+";
+            if (releaseKey >= 528040)
+                return "4.8";
+            if (releaseKey >= 461808)
+                return "4.7.2";
+            if (releaseKey >= 461308)
+                return "4.7.1";
+            if (releaseKey >= 460798)
+                return "4.7";
+            if (releaseKey >= 394802)
+                return "4.6.2";
+            if (releaseKey >= 394254)
+                return "4.6.1";
+            if (releaseKey >= 393295)
+                return "4.6";
+            if (releaseKey >= 379893)
+                return "4.5.2";
+            if (releaseKey >= 378675)
+                return "4.5.1";
+            if (releaseKey >= 378389)
+                return "4.5";
+            // This code should never execute. A non-null release key should mean
+            // that 4.5 or later is installed.
+            return "No 4.5+";
+#pragma warning restore SA1503 // Braces should not be omitted
+        }
+    }
+}
+
+#endif

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/TcpPortProvider.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/TcpPortProvider.cs
@@ -30,6 +30,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable disable
+
 using System.Net;
 using System.Net.Sockets;
 
@@ -44,14 +46,14 @@ public static class TcpPortProvider
 {
     public static int GetOpenPort()
     {
-        TcpListener? tcpListener = null;
+        TcpListener tcpListener = null;
 
         try
         {
             tcpListener = new TcpListener(IPAddress.Loopback, 0);
             tcpListener.Start();
 
-            var port = ((IPEndPoint)tcpListener.LocalEndpoint).Port;
+            int port = ((IPEndPoint)tcpListener.LocalEndpoint).Port;
 
             return port;
         }

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/TestHttpServer.AspNetCore.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/TestHttpServer.AspNetCore.cs
@@ -1,0 +1,96 @@
+// <copyright file="TestHttpServer.AspNetCore.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+// <copyright file="TestHttpServer.AspNetCore.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#nullable disable
+
+#if NET6_0_OR_GREATER
+
+using System;
+using System.Linq;
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
+using Xunit.Abstractions;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests.Helpers;
+
+public class TestHttpServer : IDisposable
+{
+    private readonly ITestOutputHelper _output;
+    private readonly RequestDelegate _requestHandler;
+    private readonly IWebHost _listener;
+
+    public TestHttpServer(ITestOutputHelper output, RequestDelegate requestHandler, string path)
+    {
+        _output = output;
+        _requestHandler = requestHandler;
+
+        _listener = new WebHostBuilder()
+            .UseKestrel(options =>
+                options.Listen(IPAddress.Loopback, 0)) // dynamic port
+            .Configure(x => x.Map(path, x =>
+            {
+                x.Run(requestHandler);
+            }))
+            .Build();
+
+        _listener.Start();
+
+        string address = _listener.ServerFeatures
+                .Get<IServerAddressesFeature>()
+                .Addresses
+                .First();
+        Port = int.Parse(address.Split(':').Last());
+        WriteOutput($"Listening on '{address}/{path}'");
+    }
+
+    /// <summary>
+    /// Gets the TCP port that this listener is listening on.
+    /// </summary>
+    public int Port { get; }
+
+    public void Dispose()
+    {
+        WriteOutput($"Shutting down");
+        _listener.Dispose();
+    }
+
+    private void WriteOutput(string msg)
+    {
+        const string name = nameof(TestHttpServer);
+        _output.WriteLine($"[{name}]: {msg}");
+    }
+}
+
+#endif

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/TestSettings.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/TestSettings.cs
@@ -30,25 +30,15 @@
 // limitations under the License.
 // </copyright>
 
+#nullable disable
+
 namespace Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests.Helpers;
 
 public class TestSettings
 {
-    public TracesSettings? TracesSettings { get; set; } = null;
-
-    public MetricsSettings? MetricsSettings { get; set; } = null;
-
-    public LogSettings? LogSettings { get; set; } = null;
-
-    public string? Arguments { get; set; } = null;
+    public string Arguments { get; set; } = null;
 
     public string PackageVersion { get; set; } = string.Empty;
 
     public string Framework { get; set; } = string.Empty;
-
-    public int AspNetCorePort { get; set; } = 5000;
-
-    public bool EnableStartupHook { get; set; } = true;
-
-    public bool EnableClrProfiler { get; set; } = true;
 }

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/TimeExtensions.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/TimeExtensions.cs
@@ -1,0 +1,67 @@
+// <copyright file="TimeExtensions.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+// <copyright file="TimeExtensions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#nullable disable
+
+using System;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests.Helpers;
+
+internal static class TimeExtensions
+{
+    private const long NanoSecondsPerTick = 1000000 / TimeSpan.TicksPerMillisecond;
+
+    private const long UnixEpochInTicks = 621355968000000000; // = DateTimeOffset.FromUnixTimeMilliseconds(0).Ticks
+
+    /// <summary>
+    /// Returns the number of nanoseconds that have elapsed since 1970-01-01T00:00:00.000Z.
+    /// </summary>
+    /// <param name="dateTimeOffset">The value to get the number of elapsed nanoseconds for.</param>
+    /// <returns>The number of nanoseconds that have elapsed since 1970-01-01T00:00:00.000Z.</returns>
+    public static long ToUnixTimeNanoseconds(this DateTimeOffset dateTimeOffset)
+    {
+        return (dateTimeOffset.Ticks - UnixEpochInTicks) * NanoSecondsPerTick;
+    }
+
+    /// <summary>
+    /// Reconverts a long timestamp from TimeExtensions.ToUnixTimeMicroseconds.
+    /// </summary>
+    /// <param name="ts">The unix time in microseconds.</param>
+    /// <returns>The corresponding DateTimeOffset.</returns>
+    public static DateTimeOffset UnixMicrosecondsToDateTimeOffset(this long ts)
+    {
+        const long microsecondsPerMillisecond = 1000;
+        const long ticksPerMicrosecond = TimeSpan.TicksPerMillisecond / microsecondsPerMillisecond;
+        var ticks = (ts * ticksPerMicrosecond) + UnixEpochInTicks;
+        return new DateTimeOffset(ticks, TimeSpan.Zero);
+    }
+}

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/Timeout.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/Timeout.cs
@@ -1,4 +1,4 @@
-// <copyright file="OutputHelper.cs" company="Splunk Inc.">
+// <copyright file="Timeout.cs" company="Splunk Inc.">
 // Copyright Splunk Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +14,7 @@
 // limitations under the License.
 // </copyright>
 
-// <copyright file="OutputHelper.cs" company="OpenTelemetry Authors">
+// <copyright file="Timeout.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,28 +32,13 @@
 
 #nullable disable
 
-using Xunit.Abstractions;
+using System;
 
 namespace Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests.Helpers;
 
-public static class OutputHelper
+internal static class Timeout
 {
-    public static void WriteResult(this ITestOutputHelper outputHelper, ProcessHelper processHelper)
-    {
-        processHelper.Drain();
-
-        var standardOutput = processHelper.StandardOutput;
-        if (!string.IsNullOrWhiteSpace(standardOutput))
-        {
-            outputHelper.WriteLine("StandardOutput:");
-            outputHelper.WriteLine(standardOutput);
-        }
-
-        var standardError = processHelper.ErrorOutput;
-        if (!string.IsNullOrWhiteSpace(standardError))
-        {
-            outputHelper.WriteLine("StandardError:");
-            outputHelper.WriteLine(standardError);
-        }
-    }
+    public static readonly TimeSpan ProcessExit = TimeSpan.FromMinutes(5); // caution: long timeouts can cause integer overflow!
+    public static readonly TimeSpan Expectation = TimeSpan.FromMinutes(1); // long to avoid flaky tests
+    public static readonly TimeSpan NoExpectation = TimeSpan.FromSeconds(3); // short to not make the tests unnecessary long
 }

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests.csproj
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests.csproj
@@ -4,6 +4,10 @@
     <!-- Suppress warnings about lowercase variable names in generated code -->
     <NoWarn>$(NoWarn);CS8981</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="System.EnterpriseServices" Condition="$(TargetFramework.StartsWith('net4'))" />
+  </ItemGroup>
   
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.21.9" />
@@ -18,16 +22,8 @@
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
-    <Reference Include="OpenTelemetry.AutoInstrumentation">
-      <HintPath>..\..\OpenTelemetryDistribution\netfx\OpenTelemetry.AutoInstrumentation.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net462' ">
-    <Reference Include="OpenTelemetry.AutoInstrumentation">
-      <HintPath>..\..\OpenTelemetryDistribution\net\OpenTelemetry.AutoInstrumentation.dll</HintPath>
-    </Reference>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net6.0' ">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I have a plan to add some more tests into integration phase.
All of them requires mock collectors. It will be great to keep it in sync with OTel .NET AutoInstrumentation.

`#nullable disable` are added due to https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/1678