### PR TITLE
Enable .NET Fx config file

### DIFF
--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/PluginSettings.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/PluginSettings.cs
@@ -53,14 +53,11 @@ internal class PluginSettings
         {
             new EnvironmentConfigurationSource(),
 
-/*
-* TODO: Enable ASP.NET web.config support
-*
 #if NETFRAMEWORK
             // on .NET Framework only, also read from app.config/web.config
             new NameValueConfigurationSource(System.Configuration.ConfigurationManager.AppSettings)
 #endif
-*/
+
         };
 
         return new PluginSettings(configurationSource);

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Splunk.OpenTelemetry.AutoInstrumentation.csproj
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Splunk.OpenTelemetry.AutoInstrumentation.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Web" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.0.0-rc9.7" />
   </ItemGroup>


### PR DESCRIPTION
### What

Enables configuration options to be taken from `Web.config` or `App.config`. 
Makes configuration options similar to upstream.