### PR TITLE
[Discussion] Add deployment.environment support

### DIFF
--- a/.cspell/company-terms.txt
+++ b/.cspell/company-terms.txt
@@ -1,1 +1,2 @@
 OTEL
+SIGNALFX

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 * Add `SPLUNK_ACCESS_TOKEN` configuration key to authorize direct ingest.
 * Add `SPLUNK_TRACE_RESPONSE_HEADER_ENABLED` configuration key
   to support Splunk RUM.
+* Add `SIGNALFX_ENV` configuration key to specify environment name.
 
 ### Changed
 

--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -47,6 +47,7 @@ Note: .NET Framework apps can read settings also from `Web.config` and `App.conf
 
 | Environment variable                   | Default | Description                                |
 |----------------------------------------|---------|--------------------------------------------|
+| `SIGNALFX_ENV`                         |         | Specifies environment name.                |
 | `SPLUNK_REALM`                         | `none`  | Specifies direct OTLP ingest realm. [1]    |
 | `SPLUNK_ACCESS_TOKEN`                  |         | Specifies direct OTLP ingest access token. |
 | `SPLUNK_TRACE_RESPONSE_HEADER_ENABLED` | `true`  | Enables Splunk RUM integration.            |

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/ConfigurationKeys.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/ConfigurationKeys.cs
@@ -18,6 +18,14 @@ namespace Splunk.OpenTelemetry.AutoInstrumentation;
 
 internal static class ConfigurationKeys
 {
+    public static class SignalFx
+    {
+        /// <summary>
+        /// Configuration key for current environment name.
+        /// </summary>
+        public const string Environment = "SIGNALFX_ENV";
+    }
+
     public static class Splunk
     {
         /// <summary>

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Logs.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Logs.cs
@@ -22,10 +22,16 @@ namespace Splunk.OpenTelemetry.AutoInstrumentation;
 internal class Logs
 {
     private readonly ILogger _log = new Logger();
+    private readonly PluginSettings _settings;
+
+    public Logs(PluginSettings settings)
+    {
+        _settings = settings;
+    }
 
     public void ConfigureLogsOptions(OpenTelemetryLoggerOptions options)
     {
         ServiceNameWarning.Instance.SendOnMissingServiceName(_log);
-        options.ConfigureResource(ResourceConfigurator.Configure);
+        options.ConfigureResource(b => ResourceConfigurator.Configure(b, _settings));
     }
 }

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Metrics.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Metrics.cs
@@ -34,7 +34,7 @@ internal class Metrics
     public MeterProviderBuilder ConfigureMeterProvider(MeterProviderBuilder builder)
     {
         ServiceNameWarning.Instance.SendOnMissingServiceName(_log);
-        return builder.ConfigureResource(ResourceConfigurator.Configure);
+        return builder.ConfigureResource(b => ResourceConfigurator.Configure(b, _settings));
     }
 
     public void ConfigureMetricsOptions(OtlpExporterOptions options)

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Plugin.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Plugin.cs
@@ -36,7 +36,7 @@ public class Plugin
 
     private readonly Metrics _metrics = new(Settings);
     private readonly Traces _traces = new(Settings);
-    private readonly Logs _logs = new();
+    private readonly Logs _logs = new(Settings);
 
     /// <summary>
     /// Configures Metrics

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/PluginSettings.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/PluginSettings.cs
@@ -35,6 +35,7 @@ internal class PluginSettings
 
         Realm = source.GetString(ConfigurationKeys.Splunk.Realm);
         AccessToken = source.GetString(ConfigurationKeys.Splunk.AccessToken);
+        EnvironmentName = source.GetString(ConfigurationKeys.SignalFx.Environment);
         TraceResponseHeaderEnabled = source.GetBool(ConfigurationKeys.Splunk.TraceResponseHeaderEnabled) ?? true;
         IsOtlpEndpointSet = !string.IsNullOrEmpty(source.GetString(ConfigurationKeys.OpenTelemetry.OtlpEndpoint));
     }
@@ -42,6 +43,8 @@ internal class PluginSettings
     public string? Realm { get; }
 
     public string? AccessToken { get; }
+
+    public string? EnvironmentName { get; }
 
     public bool TraceResponseHeaderEnabled { get; }
 

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/ResourceConfigurator.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/ResourceConfigurator.cs
@@ -23,6 +23,7 @@ namespace Splunk.OpenTelemetry.AutoInstrumentation;
 internal static class ResourceConfigurator
 {
     private const string SplunkDistroVersionName = "splunk.distro.version";
+    private const string DeploymentEnvironment = "deployment.environment";
     private static readonly string Version;
 
     static ResourceConfigurator()
@@ -32,9 +33,18 @@ internal static class ResourceConfigurator
         Version = version.FileVersion ?? "unknown";
     }
 
-    public static void Configure(ResourceBuilder resourceBuilder)
+    public static void Configure(ResourceBuilder resourceBuilder, PluginSettings settings)
     {
-        resourceBuilder
-            .AddAttributes(new KeyValuePair<string, object>[] { new(SplunkDistroVersionName, Version) });
+        var attributes = new List<KeyValuePair<string, object>>
+        {
+            new(SplunkDistroVersionName, Version)
+        };
+
+        if (!string.IsNullOrEmpty(settings.EnvironmentName))
+        {
+            attributes.Add(new(DeploymentEnvironment, settings.EnvironmentName!));
+        }
+
+        resourceBuilder.AddAttributes(attributes);
     }
 }

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Traces.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Traces.cs
@@ -42,7 +42,7 @@ internal class Traces
     public TracerProviderBuilder ConfigureTracerProvider(TracerProviderBuilder builder)
     {
         ServiceNameWarning.Instance.SendOnMissingServiceName(_log);
-        return builder.ConfigureResource(ResourceConfigurator.Configure);
+        return builder.ConfigureResource(b => ResourceConfigurator.Configure(b, _settings));
     }
 
     public void ConfigureTracesOptions(OtlpExporterOptions options)

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/SettingsTests.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/SettingsTests.cs
@@ -40,12 +40,14 @@ namespace Splunk.OpenTelemetry.AutoInstrumentation.Tests
             {
                 settings.Realm.Should().BeNull();
                 settings.AccessToken.Should().BeNull();
+                settings.EnvironmentName.Should().BeNull();
                 settings.TraceResponseHeaderEnabled.Should().BeTrue();
             }
         }
 
         private static void ClearEnvVars()
         {
+            Environment.SetEnvironmentVariable(ConfigurationKeys.SignalFx.Environment, null);
             Environment.SetEnvironmentVariable(ConfigurationKeys.Splunk.Realm, null);
             Environment.SetEnvironmentVariable(ConfigurationKeys.Splunk.AccessToken, null);
             Environment.SetEnvironmentVariable(ConfigurationKeys.Splunk.TraceResponseHeaderEnabled, null);


### PR DESCRIPTION
### What

Adds `deployment.environment` resource support via env `SIGNALFX_ENV`.
In OTel spec this is advised but for SingalFX APM this is required (for grouping and navigating purposes).

https://signalfuse.atlassian.net/browse/APMI-3667

OTel spec suggests `OTEL_RESOURCE_ATTRIBUTES` but this is not suitable in machine level.

### Tests

* Unit tests added
* Manual integration test

_https://app.signalfx.com/#/apm/traces/fc4620b36ee3c5759bd9f575397e0b1c_
![image](https://user-images.githubusercontent.com/4929112/206179591-5d67f7cd-57c0-4379-9336-46069f057234.png)

