### PR TITLE
Overwrite OTel service name if missing

### DIFF
--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Configuration/ConfigurationExtensions.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Configuration/ConfigurationExtensions.cs
@@ -1,0 +1,45 @@
+﻿// <copyright file="ConfigurationExtensions.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Configuration
+{
+    internal static class ConfigurationExtensions
+    {
+        public static IReadOnlyCollection<KeyValuePair<string, string>> ToNameValueCollection(this string configurationValue)
+        {
+            if (configurationValue == null)
+            {
+                return Array.Empty<KeyValuePair<string, string>>();
+            }
+
+            var collection = new List<KeyValuePair<string, string>>();
+
+            foreach (var attribute in configurationValue.Split(','))
+            {
+                var parts = attribute.Split('=');
+                var key = parts[0].Trim();
+                var value = parts[1].Trim();
+
+                collection.Add(new(key, value));
+            }
+
+            return collection;
+        }
+    }
+}

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/ConfigurationKeys.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/ConfigurationKeys.cs
@@ -38,6 +38,19 @@ internal static class ConfigurationKeys
 
     public static class OpenTelemetry
     {
+        /// <summary>
+        /// Configuration key for OTLP endpoint.
+        /// </summary>
         public const string OtlpEndpoint = "OTEL_EXPORTER_OTLP_ENDPOINT";
+
+        /// <summary>
+        /// Configuration key for service name.
+        /// </summary>
+        public const string ServiceName = "OTEL_SERVICE_NAME";
+
+        /// <summary>
+        /// Configuration key for resource attributes.
+        /// </summary>
+        public const string ResourceAttributes = "OTEL_RESOURCE_ATTRIBUTES";
     }
 }

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Helpers/ServiceNameHelper.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Helpers/ServiceNameHelper.cs
@@ -75,7 +75,7 @@ namespace Splunk.OpenTelemetry.AutoInstrumentation.Helpers
                 Log.Error(ex, "Error creating default service name.");
             }
 
-            return "Unkown";
+            return "unknown_service";
         }
 
 #if NETFRAMEWORK

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Helpers/ServiceNameHelper.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Helpers/ServiceNameHelper.cs
@@ -1,0 +1,98 @@
+﻿// <copyright file="ServiceNameHelper.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using Splunk.OpenTelemetry.AutoInstrumentation.Logging;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Helpers
+{
+    internal class ServiceNameHelper
+    {
+        private static readonly ILogger Log = new Logger();
+
+        public static bool HasServiceName(PluginSettings settings)
+        {
+            return !string.IsNullOrEmpty(settings.ServiceName) || ResourceHasServiceName(settings.ResourceAttributes);
+
+            bool ResourceHasServiceName(IEnumerable<KeyValuePair<string, string>> resources)
+            {
+                const string key = "service.name";
+
+                var serviceName = settings.ResourceAttributes
+                    .FirstOrDefault(x => x.Key == key)
+                    .Value;
+
+                return !string.IsNullOrEmpty(serviceName);
+            }
+        }
+
+        public static string GetGeneratedServiceName()
+        {
+            try
+            {
+#if NETFRAMEWORK
+                try
+                {
+                    if (TryLoadAspNetSiteName(out var siteName))
+                    {
+                        return siteName!;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // Unable to call into System.Web.dll
+                    Log.Error(ex, "Unable to get application name through ASP.NET settings");
+                }
+#endif
+
+                var serviceName = Assembly.GetEntryAssembly()?.GetName().Name ??
+                       Process.GetCurrentProcess()?.ProcessName;
+
+                if (!string.IsNullOrEmpty(serviceName))
+                {
+                    return serviceName!;
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error creating default service name.");
+            }
+
+            return "Unkown";
+        }
+
+#if NETFRAMEWORK
+        private static bool TryLoadAspNetSiteName(out string? siteName)
+        {
+            // System.Web.dll is only available on .NET Framework
+            if (System.Web.Hosting.HostingEnvironment.IsHosted)
+            {
+                // if this app is an ASP.NET application, return "SiteName/ApplicationVirtualPath".
+                // note that ApplicationVirtualPath includes a leading slash.
+                siteName = (System.Web.Hosting.HostingEnvironment.SiteName + System.Web.Hosting.HostingEnvironment.ApplicationVirtualPath).TrimEnd('/');
+                return true;
+            }
+
+            siteName = default;
+            return false;
+        }
+#endif
+    }
+}

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Logging/ILogger.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Logging/ILogger.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+using System;
+
 namespace Splunk.OpenTelemetry.AutoInstrumentation.Logging;
 
 /// <summary>
@@ -32,4 +34,11 @@ public interface ILogger
     /// </summary>
     /// <param name="message">Message to be logged.</param>
     void Error(string message);
+
+    /// <summary>
+    /// Logs error message.
+    /// </summary>
+    /// <param name="exception">Exception to be logged.</param>
+    /// <param name="message">Message to be logged.</param>
+    void Error(Exception exception, string message);
 }

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Logging/Logger.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Logging/Logger.cs
@@ -24,6 +24,7 @@ internal class Logger : ILogger
     private static readonly object? Log;
     private static readonly MethodInfo? WarningMethod;
     private static readonly MethodInfo? ErrorMethod;
+    private static readonly MethodInfo? ErrorWithExceptionMethod;
 
     static Logger()
     {
@@ -39,6 +40,7 @@ internal class Logger : ILogger
 
             WarningMethod = GetMethod("Warning");
             ErrorMethod = GetMethod("Error");
+            ErrorWithExceptionMethod = GetMethodWithException("Error");
         }
         catch (Exception ex)
         {
@@ -56,6 +58,11 @@ internal class Logger : ILogger
         ErrorMethod?.Invoke(Log, new object[] { message, 0, string.Empty });
     }
 
+    public void Error(Exception ex, string message)
+    {
+        ErrorWithExceptionMethod?.Invoke(Log, new object[] { ex, message, 0, string.Empty });
+    }
+
     private static MethodInfo? GetMethod(string method)
     {
         // First type is 'string messageTemplate'
@@ -65,5 +72,17 @@ internal class Logger : ILogger
         return Log?
             .GetType()
             .GetMethod(method, types: new[] { typeof(string), typeof(int), typeof(string) });
+    }
+
+    private static MethodInfo? GetMethodWithException(string method)
+    {
+        // First type is 'Exception ex'
+        // Second type is 'string messageTemplate'
+        // Last but one is '[CallerLineNumber] int sourceLine = 0'
+        // Last type is '[CallerFilePath] string sourceFile = ""'
+
+        return Log?
+            .GetType()
+            .GetMethod(method, types: new[] { typeof(Exception), typeof(string), typeof(int), typeof(string) });
     }
 }

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Logs.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Logs.cs
@@ -20,8 +20,15 @@ namespace Splunk.OpenTelemetry.AutoInstrumentation;
 
 internal class Logs
 {
+    private readonly PluginSettings _settings;
+
+    internal Logs(PluginSettings settings)
+    {
+        _settings = settings;
+    }
+
     public void ConfigureLogsOptions(OpenTelemetryLoggerOptions options)
     {
-        options.ConfigureResource(ResourceConfigurator.Configure);
+        options.ConfigureResource(b => ResourceConfigurator.Configure(b, _settings));
     }
 }

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Metrics.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Metrics.cs
@@ -40,7 +40,7 @@ internal class Metrics
 
     public MeterProviderBuilder ConfigureMeterProvider(MeterProviderBuilder builder)
     {
-        return builder.ConfigureResource(ResourceConfigurator.Configure);
+        return builder.ConfigureResource(b => ResourceConfigurator.Configure(b, _settings));
     }
 
     public void ConfigureMetricsOptions(OtlpExporterOptions options)

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Plugin.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Plugin.cs
@@ -36,7 +36,7 @@ public class Plugin
 
     private readonly Metrics _metrics = new(Settings);
     private readonly Traces _traces = new(Settings);
-    private readonly Logs _logs = new();
+    private readonly Logs _logs = new(Settings);
     private readonly Sdk _sdk = new();
 
     /// <summary>

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/PluginSettings.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/PluginSettings.cs
@@ -15,6 +15,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using Splunk.OpenTelemetry.AutoInstrumentation.Configuration;
 
 namespace Splunk.OpenTelemetry.AutoInstrumentation;
@@ -35,17 +36,23 @@ internal class PluginSettings
 
         Realm = source.GetString(ConfigurationKeys.Splunk.Realm) ?? Constants.None;
         AccessToken = source.GetString(ConfigurationKeys.Splunk.AccessToken);
+        ServiceName = source.GetString(ConfigurationKeys.OpenTelemetry.ServiceName);
         TraceResponseHeaderEnabled = source.GetBool(ConfigurationKeys.Splunk.TraceResponseHeaderEnabled) ?? true;
         IsOtlpEndpointSet = !string.IsNullOrEmpty(source.GetString(ConfigurationKeys.OpenTelemetry.OtlpEndpoint));
+        ResourceAttributes = source.GetString(ConfigurationKeys.OpenTelemetry.ResourceAttributes)!.ToNameValueCollection();
     }
 
     public string Realm { get; }
 
     public string? AccessToken { get; }
 
+    public string? ServiceName { get; }
+
     public bool TraceResponseHeaderEnabled { get; }
 
     public bool IsOtlpEndpointSet { get; }
+
+    public IReadOnlyCollection<KeyValuePair<string, string>> ResourceAttributes { get; }
 
     public static PluginSettings FromDefaultSources()
     {

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/ResourceConfigurator.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/ResourceConfigurator.cs
@@ -18,11 +18,15 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using OpenTelemetry.Resources;
 
+using static Splunk.OpenTelemetry.AutoInstrumentation.Helpers.ServiceNameHelper;
+
 namespace Splunk.OpenTelemetry.AutoInstrumentation;
 
 internal static class ResourceConfigurator
 {
     private const string SplunkDistroVersionName = "splunk.distro.version";
+    private const string ServiceName = "service.name";
+
     private static readonly string Version;
 
     static ResourceConfigurator()
@@ -32,9 +36,18 @@ internal static class ResourceConfigurator
         Version = version.FileVersion ?? "unknown";
     }
 
-    public static void Configure(ResourceBuilder resourceBuilder)
+    public static void Configure(ResourceBuilder resourceBuilder, PluginSettings settings)
     {
-        resourceBuilder
-            .AddAttributes(new KeyValuePair<string, object>[] { new(SplunkDistroVersionName, Version) });
+        var attributes = new List<KeyValuePair<string, object>>
+        {
+            new(SplunkDistroVersionName, Version)
+        };
+
+        if (!HasServiceName(settings))
+        {
+            attributes.Add(new(ServiceName, GetGeneratedServiceName()));
+        }
+
+        resourceBuilder.AddAttributes(attributes);
     }
 }

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Traces.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Traces.cs
@@ -48,7 +48,7 @@ internal class Traces
 
     public TracerProviderBuilder ConfigureTracerProvider(TracerProviderBuilder builder)
     {
-        return builder.ConfigureResource(ResourceConfigurator.Configure);
+        return builder.ConfigureResource(b => ResourceConfigurator.Configure(b, _settings));
     }
 
     public void ConfigureTracesOptions(OtlpExporterOptions options)

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/ConfigurationExtensionsTests.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/ConfigurationExtensionsTests.cs
@@ -1,0 +1,38 @@
+﻿// <copyright file="ConfigurationExtensionsTests.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Collections.Generic;
+using FluentAssertions.Execution;
+using Splunk.OpenTelemetry.AutoInstrumentation.Configuration;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Tests
+{
+    public class ConfigurationExtensionsTests
+    {
+        [Fact]
+        public void ToNameValueCollection()
+        {
+            var setting = "item.value=1, service.name=test";
+            var collection = setting.ToNameValueCollection();
+
+            using (new AssertionScope())
+            {
+                collection.Should().Contain(new KeyValuePair<string, string>("item.value", "1"));
+                collection.Should().Contain(new KeyValuePair<string, string>("service.name", "test"));
+            }
+        }
+    }
+}

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/ResourceConfiguratorTests.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/ResourceConfiguratorTests.cs
@@ -14,10 +14,12 @@
 // limitations under the License.
 // </copyright>
 
+using System.Collections.Specialized;
 using System.Linq;
 using System.Reflection;
 using FluentAssertions.Execution;
 using OpenTelemetry.Resources;
+using Splunk.OpenTelemetry.AutoInstrumentation.Configuration;
 
 namespace Splunk.OpenTelemetry.AutoInstrumentation.Tests;
 
@@ -28,13 +30,21 @@ public class ResourceConfiguratorTests
     {
         var resourceBuilder = ResourceBuilder.CreateEmpty();
 
-        ResourceConfigurator.Configure(resourceBuilder);
+        var configuration = new NameValueCollection
+        {
+            { "OTEL_SERVICE_NAME", "MyServiceName" },
+        };
+
+        var settings = new PluginSettings(new NameValueConfigurationSource(configuration));
+
+        ResourceConfigurator.Configure(resourceBuilder, settings);
 
         var resource = resourceBuilder.Build();
 
         using (new AssertionScope())
         {
             resource.Attributes.Count().Should().Be(1);
+
             var attribute = resource.Attributes.First();
             attribute.Key.Should().Be("splunk.distro.version");
             (attribute.Value as string).Should().Be(typeof(Plugin).Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version);

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/ServiceNameHelperTests.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/ServiceNameHelperTests.cs
@@ -1,0 +1,51 @@
+﻿// <copyright file="ServiceNameHelperTests.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Collections.Specialized;
+using Splunk.OpenTelemetry.AutoInstrumentation.Configuration;
+using Splunk.OpenTelemetry.AutoInstrumentation.Helpers;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Tests
+{
+    public class ServiceNameHelperTests
+    {
+        [Theory]
+        [InlineData("OTEL_SERVICE_NAME", null, false)]
+        [InlineData("OTEL_SERVICE_NAME", "", false)]
+        [InlineData("OTEL_SERVICE_NAME", "MyServiceName", true)]
+        [InlineData("OTEL_RESOURCE_ATTRIBUTES", null, false)]
+        [InlineData("OTEL_RESOURCE_ATTRIBUTES", "", false)]
+        [InlineData("OTEL_RESOURCE_ATTRIBUTES", "something.else=MyName", false)]
+        [InlineData("OTEL_RESOURCE_ATTRIBUTES", "service.name= ", false)]
+        [InlineData("OTEL_RESOURCE_ATTRIBUTES", "service.name=MyName", true)]
+        [InlineData("OTEL_RESOURCE_ATTRIBUTES", "service.name=MyName,service.namespace=Temp", true)]
+        [InlineData("OTEL_RESOURCE_ATTRIBUTES", "service.namespace=Temp,service.name=MyName", true)]
+        [InlineData("OTEL_RESOURCE_ATTRIBUTES", "test1.thing=MyName,test2.thing=Temp", false)]
+        public void ServiceNameExists(string configKey, string configValue, bool expected)
+        {
+            var configuration = new NameValueCollection
+            {
+                { configKey, configValue },
+            };
+
+            var settings = new PluginSettings(new NameValueConfigurationSource(configuration));
+
+            var result = ServiceNameHelper.HasServiceName(settings);
+
+            result.Should().Be(expected);
+        }
+    }
+}


### PR DESCRIPTION
### What

Changes OTel service name generation from unkown_service:ProcessName to the same logic from SignalFx.

https://signalfuse.atlassian.net/browse/APMI-3666

### Tests

Service name = AspNetTracingTest (Inproc ASP.NET Core hosted in IIS, Entry assembly name)
https://app.signalfx.com/#/apm/traces/6dd338b935d9558f8170181c99eb471c

Service name = OTelFX (ASP.NET MVC hosted in IIS, IIS Website name)
https://app.signalfx.com/#/apm/traces/2fca52f6cc2eb4a730fa9e65d041176e

Notice: There is a conflict between spec and Zero config.
https://github.com/signalfx/gdi-specification/blob/6d04201f3472c83792666d1477aa770027c9a069/specification/configuration.md?plain=1#L202-L213