### PR TITLE
Add workflow to build docker image for Operator based instrumentation

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,0 +1,43 @@
+name: publish splunk-otel-dotnet docker image to ghcr
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3.3.0
+
+      - uses: docker/setup-buildx-action@v2
+
+      - name: Put GITHUB_REF_NAME into env
+        run: echo GITHUB_REF_NAME=${GITHUB_REF_NAME} >> $GITHUB_ENV
+
+      - name: Set the major version number
+        run: echo MAJOR_VERSION=${GITHUB_REF_NAME} | sed -e 's/\..*//' >> $GITHUB_ENV
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: build and publish container
+        uses: docker/build-push-action@v4.0.0
+        with:
+          push: true
+          file: Dockerfile-ghcr
+          build-args: |
+            RELEASE_VER=${{ env.GITHUB_REF_NAME }}
+          tags: |
+            ghcr.io/signalfx/splunk-otel-dotnet/splunk-otel-dotnet:latest
+            ghcr.io/signalfx/splunk-otel-dotnet/splunk-otel-dotnet:${{ env.MAJOR_VERSION }}
+            ghcr.io/signalfx/splunk-otel-dotnet/splunk-otel-dotnet:${{ env.GITHUB_REF_NAME }}
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# To build one auto-instrumentation image for dotnet, please:
+#  - Download your dotnet auto-instrumentation artifacts to `/autoinstrumentation` 
+#    directory. This is required as when instrumenting the pod, one init 
+#    container will be created to copy the files to your app's container.
+#  - Symlink '/autoinstrumentation/splunk-opentelemetry-dotnet-linux-glibc' to `/autoinstrumentation/opentelemetry-dotnet-instrumentation-linux-glibc`
+#    to support compatability with the https://github.com/open-telemetry/opentelemetry-operator 
+#    project.
+#  - Grant the necessary access to the files in the `/autoinstrumentation` directory.
+#  - Following environment variables are injected to the application container to enable the auto-instrumentation.
+#    CORECLR_ENABLE_PROFILING=1
+#    CORECLR_PROFILER={918728DD-259F-4A6A-AC2B-B85E1B658318}
+#    CORECLR_PROFILER_PATH=%InstallationLocation%/linux-x64/OpenTelemetry.AutoInstrumentation.Native.so
+#    DOTNET_ADDITIONAL_DEPS=%InstallationLocation%/AdditionalDeps
+#    DOTNET_SHARED_STORE=%InstallationLocation%/store
+#    DOTNET_STARTUP_HOOKS=%InstallationLocation%/net/OpenTelemetry.AutoInstrumentation.StartupHook.dll 
+#    OTEL_DOTNET_AUTO_HOME=%InstallationLocation%
+#  - For auto-instrumentation by container injection, the Linux command cp is
+#    used and must be availabe in the image.
+FROM busybox
+
+ARG RELEASE_VER
+ENV RELEASE_VER=$RELEASE_VER
+
+WORKDIR /autoinstrumentation
+
+ADD https://github.com/signalfx/splunk-otel-dotnet/releases/download/${RELEASE_VER}/splunk-opentelemetry-dotnet-linux-glibc.zip .
+RUN unzip ./splunk-opentelemetry-dotnet-linux-glibc.zip
+RUN ln -s ./splunk-opentelemetry-dotnet-linux-glibc ./opentelemetry-dotnet-instrumentation-linux-glibc
+
+RUN chmod -R 644 .


### PR DESCRIPTION
Description:
- Hoping to dockerize the Splunk dotnet instrumentation  library soon. 
- Creating a draft PR now for visibility. 
- Most of these changes are for the requirements from the [upstream OpTelemetry Operator](https://github.com/open-telemetry/opentelemetry-operator/blob/main/autoinstrumentation/dotnet/Dockerfile).
- We may need to add more changes for splunk-otel-dotnet, still working on this.
- Still need to test and verify the functionality integrity of Operator based .net auto-instrumentation