### PR TITLE
Fix Nuget recommendations

### DIFF
--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Splunk.OpenTelemetry.AutoInstrumentation.csproj
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Splunk.OpenTelemetry.AutoInstrumentation.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <PackageReference Include="MinVer" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>
@@ -32,6 +32,7 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageReleaseNotes>See release notes at https://github.com/signalfx/splunk-otel-dotnet/releases</PackageReleaseNotes>
     <PackageTags>OpenTelemetry;OTEL;APM;tracing;profiling;instrumentation;Splunk</PackageTags>
+    <Description>Splunk Distribution of OpenTelemetry .NET package with all required components to enable automatic instrumentation.</Description>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/signalfx/splunk-otel-dotnet.git</RepositoryUrl>
     <Copyright>Copyright 2023 Splunk Inc.</Copyright>

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Splunk.OpenTelemetry.AutoInstrumentation.csproj
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Splunk.OpenTelemetry.AutoInstrumentation.csproj
@@ -1,5 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="MinVer" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Local check for nuget build on GH CI:

`dotnet validate package local .\Splunk.OpenTelemetry.AutoInstrumentation.1.0.0-rc.1.12.nupkg`
```log
Validating C:\temp\opentelemetry-dotnet-instrumentation-nuget-packages\Splunk.OpenTelemetry.AutoInstrumentation.1.0.0-rc.1.12.nupkg
 Source Link: ? Valid

 Deterministic (dll/exe): ? Valid

 Compiler Flags: ? Valid
```


`meziantou.validate-nuget-package .\Splunk.OpenTelemetry.AutoInstrumentation.1.0.0-rc.1.12.nupkg`

```json
{
  "IsValid": true,
  "Packages": {
    "C:\\temp\\opentelemetry-dotnet-instrumentation-nuget-packages\\Splunk.OpenTelemetry.AutoInstrumentation.1.0.0-rc.1.12.nupkg": {
      "Errors": [],
      "IsValid": true
    }
  }
}
```