### PR TITLE
Disable NU5104 warnings

### DIFF
--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Splunk.OpenTelemetry.AutoInstrumentation.csproj
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Splunk.OpenTelemetry.AutoInstrumentation.csproj
@@ -1,4 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5104 -->
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
A stable release of a package should not have a prerelease dependency.

To unblock 1.0.2 release.

Changes tested locally.