### PR TITLE
Plugin should be platform agnostic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,12 +52,12 @@ jobs:
           Import-Module "${PWD}/bin/InstallationScripts/Splunk.OTel.DotNet.psm1"
           [System.Environment]::SetEnvironmentVariable("SPLUNK_OTEL_DOTNET_AUTO_INSTALL_DIR", "${PWD}\OpenTelemetryDistribution", [System.EnvironmentVariableTarget]::Machine)
           Register-OpenTelemetryForCurrentSession -OTelServiceName "MyServiceDisplayName"
-          ./test/test-applications/integrations/TestApplication.Smoke/bin/x64/Release/net7.0/TestApplication.Smoke.exe
+          ./test/test-applications/integrations/TestApplication.Smoke/bin/Release/net7.0/TestApplication.Smoke.exe
           if (-not $?) { throw "dotnet help returned exit code: $LASTEXITCODE" }
           if (-not (Test-Path $log_path)) { throw "Log file does not exist. Instrumentation test failed." }
           Remove-Item $log_path
           Unregister-OpenTelemetryForCurrentSession
-          ./test/test-applications/integrations/TestApplication.Smoke/bin/x64/Release/net7.0/TestApplication.Smoke.exe
+          ./test/test-applications/integrations/TestApplication.Smoke/bin/Release/net7.0/TestApplication.Smoke.exe
           if (-not $?) { throw "dotnet help returned exit code: $LASTEXITCODE" }
           if (Test-Path $log_path) { throw "Log file exists. Instrumentation unregister failed." }
       - uses: actions/upload-artifact@v3.1.3

--- a/build/Build.NuGet.cs
+++ b/build/Build.NuGet.cs
@@ -31,8 +31,7 @@ partial class Build : NukeBuild
                 .SetProperty("NuGetPackageVersion", VersionHelper.GetVersion())
                 .SetRuntime(RuntimeInformation.RuntimeIdentifier)
                 .SetSelfContained(true)
-                .SetConfiguration(Configuration)
-                .SetPlatform(Platform));
+                .SetConfiguration(Configuration));
         });
 
     Target RunNuGetPackageIntegrationTests => _ => _

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -17,9 +17,6 @@ partial class Build : NukeBuild
     [Parameter("Configuration to build - Default is 'Release'")]
     readonly Configuration Configuration = Configuration.Release;
 
-    [Parameter("Platform to build - x86 or x64. Default is 'x64'")]
-    readonly MSBuildTargetPlatform Platform = MSBuildTargetPlatform.x64;
-
     const string OpenTelemetryAutoInstrumentationDefaultVersion = "v1.0.2";
 
     [Parameter($"OpenTelemetry AutoInstrumentation dependency version - Default is '{OpenTelemetryAutoInstrumentationDefaultVersion}'")]
@@ -46,8 +43,7 @@ partial class Build : NukeBuild
             foreach (var project in AllProjectsExceptNuGetTestApps())
             {
                 DotNetRestore(s => s
-                    .SetProjectFile(project)
-                    .SetPlatform(Platform));
+                    .SetProjectFile(project));
             }
         });
 
@@ -107,14 +103,14 @@ partial class Build : NukeBuild
         .Executes(() =>
         {
             FileSystemTasks.CopyFileToDirectory(
-                RootDirectory / "src" / "Splunk.OpenTelemetry.AutoInstrumentation" / "bin" / ((string)Platform).ToLower() / Configuration /
+                RootDirectory / "src" / "Splunk.OpenTelemetry.AutoInstrumentation" / "bin" / Configuration /
                 "net6.0" / "Splunk.OpenTelemetry.AutoInstrumentation.dll",
                 OpenTelemetryDistributionFolder / "net");
 
             if (EnvironmentInfo.IsWin)
             {
                 FileSystemTasks.CopyFileToDirectory(
-                    RootDirectory / "src" / "Splunk.OpenTelemetry.AutoInstrumentation" / "bin" / ((string)Platform).ToLower() / Configuration /
+                    RootDirectory / "src" / "Splunk.OpenTelemetry.AutoInstrumentation" / "bin" / Configuration /
                     "net462" / "Splunk.OpenTelemetry.AutoInstrumentation.dll",
                     OpenTelemetryDistributionFolder / "netfx");
             }
@@ -175,8 +171,7 @@ Copyright The OpenTelemetry Authors under Apache License Version 2.0
                 DotNetBuild(s => s
                     .SetProjectFile(project)
                     .SetNoRestore(true)
-                    .SetConfiguration(Configuration)
-                    .SetPlatform(Platform));
+                    .SetConfiguration(Configuration));
             }
         });
 
@@ -189,8 +184,7 @@ Copyright The OpenTelemetry Authors under Apache License Version 2.0
             DotNetTest(s => s
                 .SetNoBuild(true)
                 .SetProjectFile(project)
-                .SetConfiguration(Configuration)
-                .SetProperty("Platform", Platform));
+                .SetConfiguration(Configuration));
         });
 
     Target RunIntegrationTests => _ => _
@@ -204,8 +198,7 @@ Copyright The OpenTelemetry Authors under Apache License Version 2.0
                 .SetNoBuild(true)
                 .SetProjectFile(project)
                 .SetFilter("Category!=NuGetPackage")
-                .SetConfiguration(Configuration)
-                .SetProperty("Platform", Platform));
+                .SetConfiguration(Configuration));
         });
 
     Target Workflow => _ => _

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/EnvironmentHelper.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/EnvironmentHelper.cs
@@ -233,7 +233,6 @@ public class EnvironmentHelper
         return Path.Combine(
             binDir,
             packageVersion,
-            EnvironmentTools.GetPlatform().ToLowerInvariant(),
             EnvironmentTools.GetBuildConfiguration(),
             targetFramework);
     }


### PR DESCRIPTION
Building the plugin specifying a platform makes it only usable on that platform. This change removes the platform from the build of the project.