### PR TITLE
splunk-otel-version same as release version

### DIFF
--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/ResourceConfigurator.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/ResourceConfigurator.cs
@@ -14,7 +14,7 @@
 // limitations under the License.
 // </copyright>
 
-using System.Diagnostics;
+using System.Reflection;
 using OpenTelemetry.Resources;
 
 namespace Splunk.OpenTelemetry.AutoInstrumentation;
@@ -27,9 +27,18 @@ internal static class ResourceConfigurator
 
     static ResourceConfigurator()
     {
-        var assembly = typeof(ResourceConfigurator).Assembly;
-        var version = FileVersionInfo.GetVersionInfo(assembly.Location);
-        Version = version.FileVersion ?? "unknown";
+        var assemblyInformationalVersion = typeof(ResourceConfigurator).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        if (string.IsNullOrWhiteSpace(assemblyInformationalVersion))
+        {
+            Version = "unknown";
+        }
+        else
+        {
+            var indexOfPlusSign = assemblyInformationalVersion!.IndexOf('+');
+            Version = indexOfPlusSign > 0
+                ? assemblyInformationalVersion.Substring(0, indexOfPlusSign)
+                : assemblyInformationalVersion;
+        }
     }
 
     public static void Configure(ResourceBuilder resourceBuilder, PluginSettings settings)

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/ResourceExpectorExtensions.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/Helpers/ResourceExpectorExtensions.cs
@@ -21,7 +21,7 @@ namespace Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests.Helpers;
 internal static class ResourceExpectorExtensions
 {
     private static readonly string ExpectedSdkVersion = typeof(global::OpenTelemetry.Resources.Resource).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion.Split('+')[0];
-    private static readonly string ExpectedDistributionVersion = typeof(Plugin).Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()!.Version;
+    private static readonly string ExpectedDistributionVersion = typeof(Plugin).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion.Split('+')[0];
 
     public static void ExpectDistributionResources(this OtlpResourceExpector resourceExpector, string serviceName)
     {

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/ResourceConfiguratorTests.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/ResourceConfiguratorTests.cs
@@ -46,7 +46,7 @@ public class ResourceConfiguratorTests
 
             var attribute = resource.Attributes.First();
             attribute.Key.Should().Be("splunk.distro.version");
-            (attribute.Value as string).Should().Be(typeof(Plugin).Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version);
+            (attribute.Value as string).Should().Be(typeof(Plugin).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion.Split('+')[0]);
         }
     }
 }


### PR DESCRIPTION
After changes:
`telemetry.sdk.version`: `1.6.0`
`splunk.distro.version`: `1.0.3-alpha.0.10`

before changes:
`telemetry.sdk.version`: `1.6.0`
`splunk.distro.version`: `1.0.3.0`

sdk version has same logic