### PR TITLE
Build Docker image for Splunk Operator

### DIFF
--- a/.github/workflows/publish-operator-docker-image.yml
+++ b/.github/workflows/publish-operator-docker-image.yml
@@ -1,0 +1,57 @@
+name: publish splunk-otel-dotnet operator docker image to ghcr
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4.1.1
+        with:
+          fetch-depth: 0
+
+      - uses: docker/setup-buildx-action@v3.0.0
+
+      - name: Get the latest release version
+        run: |
+          if [[ "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.x$ ]]; then
+            # get the latest tag on the release branch
+            RELEASE_VERSION="$(git describe --abbrev=0)"
+          elif [[ "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            RELEASE_VERSION="$GITHUB_REF_NAME"
+          else 
+            echo "This script can only be run on the tag or a release branch"
+            exit 1
+          fi
+          echo RELEASE_VERSION=${RELEASE_VERSION} >> $GITHUB_ENV
+
+      - name: Set the major version number
+        run: echo MAJOR_VERSION=${GITHUB_REF_NAME} | sed -e 's/\..*//' >> $GITHUB_ENV
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: build and publish container
+        uses: docker/build-push-action@v5.1.0
+        with:
+          push: true
+          file: Dockerfile
+          platforms: linux/amd64
+          build-args: |
+            RELEASE_VER=${{ env.RELEASE_VERSION }}
+          tags: |
+            ghcr.io/signalfx/splunk-otel-dotnet/splunk-otel-dotnet:latest
+            ghcr.io/signalfx/splunk-otel-dotnet/splunk-otel-dotnet:${{ env.MAJOR_VERSION }}
+            ghcr.io/signalfx/splunk-otel-dotnet/splunk-otel-dotnet:${{ env.RELEASE_VERSION }}
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # To build one auto-instrumentation image for dotnet, please:
-#  - Download your dotnet auto-instrumentation artefacts to `/autoinstrumentation` directory. This is required as when instrumenting the pod,
+#  - Download your dotnet auto-instrumentation artifacts to the `/autoinstrumentation` directory. This is required as when instrumenting the pod,
 #    one init container will be created to copy the files to your app's container.
 #  - Grant the necessary access to the files in the `/autoinstrumentation` directory.
-#  - Following environment variables are injected to the application container to enable the auto-instrumentation.
+#  - Following environment variables are injected by the k8s operator to the application container to enable the .NET auto-instrumentation.
 #    CORECLR_ENABLE_PROFILING=1
 #    CORECLR_PROFILER={918728DD-259F-4A6A-AC2B-B85E1B658318}
 #    CORECLR_PROFILER_PATH=%InstallationLocation%/linux-x64/OpenTelemetry.AutoInstrumentation.Native.so # for glibc based images

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# To build one auto-instrumentation image for dotnet, please:
+#  - Download your dotnet auto-instrumentation artefacts to `/autoinstrumentation` directory. This is required as when instrumenting the pod,
+#    one init container will be created to copy the files to your app's container.
+#  - Grant the necessary access to the files in the `/autoinstrumentation` directory.
+#  - Following environment variables are injected to the application container to enable the auto-instrumentation.
+#    CORECLR_ENABLE_PROFILING=1
+#    CORECLR_PROFILER={918728DD-259F-4A6A-AC2B-B85E1B658318}
+#    CORECLR_PROFILER_PATH=%InstallationLocation%/linux-x64/OpenTelemetry.AutoInstrumentation.Native.so # for glibc based images
+#    CORECLR_PROFILER_PATH=%InstallationLocation%/linux-musl-x64/OpenTelemetry.AutoInstrumentation.Native.so # for musl based images
+#    DOTNET_ADDITIONAL_DEPS=%InstallationLocation%/AdditionalDeps
+#    DOTNET_SHARED_STORE=%InstallationLocation%/store
+#    DOTNET_STARTUP_HOOKS=%InstallationLocation%/net/OpenTelemetry.AutoInstrumentation.StartupHook.dll 
+#    OTEL_DOTNET_AUTO_HOME=%InstallationLocation%
+#    OTEL_DOTNET_AUTO_PLUGINS=Splunk.OpenTelemetry.AutoInstrumentation.Plugin, Splunk.OpenTelemetry.AutoInstrumentation
+#  - For auto-instrumentation by container injection, the Linux command cp is
+#    used and must be availabe in the image.
+FROM busybox
+
+LABEL org.opencontainers.image.source="https://github.com/signalfx/splunk-otel-dotnet"
+LABEL org.opencontainers.image.description="Splunk Distribution of OpenTelemetry .NET"
+
+ARG RELEASE_VER
+
+WORKDIR /autoinstrumentation
+
+ADD https://github.com/signalfx/splunk-otel-dotnet/releases/download/$RELEASE_VER/splunk-opentelemetry-dotnet-linux-glibc.zip .
+ADD https://github.com/signalfx/splunk-otel-dotnet/releases/download/$RELEASE_VER/splunk-opentelemetry-dotnet-linux-musl.zip .
+
+RUN unzip splunk-opentelemetry-dotnet-linux-glibc.zip &&\
+    unzip splunk-opentelemetry-dotnet-linux-musl.zip "linux-musl-x64/*" -d . &&\
+    rm splunk-opentelemetry-dotnet-linux-glibc.zip splunk-opentelemetry-dotnet-linux-musl.zip &&\
+    chmod -R go+r .

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -34,6 +34,8 @@ No changes in the code are needed to correctly version this package.
     directory.
     1. Upload and publish the package to nuget.org.
 
+1. Verify if operator-docker image was published.
+
 1. Ask [o11y-docs team](https://github.com/orgs/splunk/teams/o11y-docs)
 to publish necessary updates to the [documentation](https://github.com/splunk/public-o11y-docs).
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -34,7 +34,7 @@ No changes in the code are needed to correctly version this package.
     directory.
     1. Upload and publish the package to nuget.org.
 
-1. Verify if operator-docker image was published.
+1. Check that the `operator-docker` image has been published.
 
 1. Ask [o11y-docs team](https://github.com/orgs/splunk/teams/o11y-docs)
 to publish necessary updates to the [documentation](https://github.com/splunk/public-o11y-docs).


### PR DESCRIPTION
@jvoravong please review.

You can check the build on my fork https://github.com/Kielek/splunk-otel-dotnet/actions/runs/7059027432/job/19215767446 and test the docker image by `ghcr.io/kielek/splunk-otel-dotnet/splunk-otel-dotnet:latest`.

Created based on
* https://github.com/open-telemetry/opentelemetry-operator/blob/main/autoinstrumentation/dotnet/Dockerfile
* https://github.com/signalfx/splunk-otel-java/blob/main/Dockerfile-ghcr
* https://github.com/signalfx/splunk-otel-java/blob/main/.github/workflows/publish-docker-image-ghcr.yml