### PR TITLE
[Tests] Drop reference to Microsoft.AspNetCore

### DIFF
--- a/test/test-applications/integrations/TestApplication.HttpServer/Program.cs
+++ b/test/test-applications/integrations/TestApplication.HttpServer/Program.cs
@@ -14,28 +14,18 @@
 // limitations under the License.
 // </copyright>
 
+using TestApplication.HttpServer;
 using TestApplication.Shared;
 
-namespace TestApplication.HttpServer;
+ConsoleHelper.WriteSplashScreen(args);
 
-public class Program
-{
-    public static void Main(string[] args)
-    {
-        ConsoleHelper.WriteSplashScreen(args);
+var builder = WebApplication.CreateBuilder(args);
 
-        var builder = WebApplication.CreateBuilder(args);
+const string requestPath = "/request";
+var app = builder.Build();
+using var observer = new LifetimeObserver(app, requestPath);
 
-        var requestPath = "/request";
-        var app = builder.Build();
-        using var observer = new LifetimeObserver(app, requestPath);
+app.UseWelcomePage("/alive-check");
+app.MapGet(requestPath, () => "TestApplication.HttpServer");
 
-        app.UseWelcomePage("/alive-check");
-        app.MapGet(requestPath, () =>
-        {
-            return "TestApplication.HttpServer";
-        });
-
-        app.Run();
-    }
-}
+app.Run();

--- a/test/test-applications/integrations/TestApplication.HttpServer/TestApplication.HttpServer.csproj
+++ b/test/test-applications/integrations/TestApplication.HttpServer/TestApplication.HttpServer.csproj
@@ -5,7 +5,6 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />


### PR DESCRIPTION
One of the builds: error NU3021: Warning As Error: Package 'Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions 2.2.0'