### PR TITLE
Update publish-operator-docker-image.yml for arm support

### DIFF
--- a/.github/workflows/publish-operator-docker-image.yml
+++ b/.github/workflows/publish-operator-docker-image.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           push: true
           file: Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           build-args: |
             RELEASE_VER=${{ env.RELEASE_VERSION }}
           tags: |


### PR DESCRIPTION
Description: v1.5.0 of .NET instrumentation added support for arm. Need to update the docker image build workflow to also build docker images for both amd and arm.