### PR TITLE
Update GDI Specification to 1.7.0

### DIFF
--- a/.cspell/other.txt
+++ b/.cspell/other.txt
@@ -11,6 +11,7 @@ myapp
 opentelemetry
 opentracing
 OTLP
+parentbased
 proto
 protos
 signalfx

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,9 @@ GitHub provides additional documentation on [forking a
 repository](https://help.github.com/articles/fork-a-repo/) and [creating a pull
 request](https://help.github.com/articles/creating-a-pull-request/).
 
+Before your contribution can be accepted, you will be asked to sign our
+[Splunk Contributor License Agreement (CLA)](https://github.com/splunk/cla-agreement/blob/main/CLA.md).
+
 ## Finding contributions to work on
 
 Looking at the existing issues is a great way to find something to contribute
@@ -86,7 +89,3 @@ any 'help wanted' issues is a great place to start.
 
 See the [LICENSE](LICENSE) file for our repository's licensing. We will ask you to
 confirm the licensing of your contribution.
-
-### Contributor License Agreement
-
-Before contributing, you must sign the [Splunk Contributor License Agreement (CLA)](https://www.splunk.com/en_us/form/contributions.html).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![OpenTelemetry .NET](https://img.shields.io/badge/OTel-1.10.0-blueviolet)](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.10.0)
 [![OpenTelemetry .NET Auto Instrumentation](https://img.shields.io/badge/OTelAuto-v1.10.0.beta.1-blueviolet)](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v1.10.0-beta.1)
-[![Splunk GDI Specification](https://img.shields.io/badge/GDI-1.6.0-blueviolet)](https://github.com/signalfx/gdi-specification/releases/tag/v1.6.0)
+[![Splunk GDI Specification](https://img.shields.io/badge/GDI-1.7.0-blueviolet)](https://github.com/signalfx/gdi-specification/releases/tag/v1.7.0)
 [![Keep a Changelog](https://img.shields.io/badge/changelog-Keep%20a%20Changelog-%23E05735)](CHANGELOG.md)
 [![LICENSE](https://img.shields.io/github/license/signalfx/splunk-otel-dotnet)](LICENSE)
 

--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -70,4 +70,5 @@ Note: .NET Framework apps can read settings also from `Web.config` and `App.conf
 This distribution follows [GDI Specification](https://github.com/signalfx/gdi-specification/blob/v1.7.0).
 There is one known difference in the default configuration.
 This package by default sets `OTEL_TRACES_SAMPLER`
-to `parentbased_always_on` instead of `always_on`.
+to `parentbased_always_on` instead of `always_on`
+for backwards compatibility.

--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -12,14 +12,14 @@ for configuration details.
 
 ## Splunk distribution configuration
 
-## Manual installation
+### Manual installation
 
 Download and install the latest binaries from
 [the latest release](https://github.com/signalfx/splunk-otel-dotnet/releases/latest).
 
 > The path where you place the binaries is referenced as `$INSTALL_DIR` in this documentation.
 
-## Manual instrumentation
+### Manual instrumentation
 
 When running your application, make sure to:
 
@@ -47,7 +47,7 @@ When running your application, make sure to:
 
 > Some settings can be omitted on .NET. For more information, see the [documentation](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/v1.10.0-beta.1/docs/config.md#net-clr-profiler).
 
-## Splunk plugin settings
+### Splunk plugin settings
 
 Note: .NET Framework apps can read settings also from `Web.config` and `App.config`.
 
@@ -64,3 +64,10 @@ Note: .NET Framework apps can read settings also from `Web.config` and `App.conf
   based on the defined realm. If both `SPLUNK_REALM` and
   `OTEL_EXPORTER_*_ENDPOINT` are set then `OTEL_EXPORTER_*_ENDPOINT` takes
   precedence.
+
+### Known differences to GDI Specification
+
+This distribution follows [GDI Specification](https://github.com/signalfx/gdi-specification/blob/v1.7.0).
+There is one known difference in the default configuration.
+This package by default sets `OTEL_TRACES_SAMPLER`
+to `parentbased_always_on` instead of `always_on`.


### PR DESCRIPTION
Fixes #582
Handles https://github.com/signalfx/gdi-specification/releases/tag/v1.7.0

#### Enhancements

- Clarify the default sampling algorithm. - differences documented. Agreed with PM to keep as is.
  [#284](https://github.com/signalfx/gdi-specification/pull/284)
- Require a CLA Assistant GitHub workflow. - already done
  [#269](https://github.com/signalfx/gdi-specification/pull/269)
- Update the CLA notice in `CONTRIBUTING.md` template. - updated in this PR
  [#269](https://github.com/signalfx/gdi-specification/pull/269)
  [#274](https://github.com/signalfx/gdi-specification/pull/274)
- Add Renovate as an acceptable alternative to Dependabot. - N/A
  [#271](https://github.com/signalfx/gdi-specification/pull/271)
- Add disk buffering configuration options for RUM mobile instrumentation libraries.
  [#275](https://github.com/signalfx/gdi-specification/pull/275)
- Update telemetry resource attributes - already done
  [#277](https://github.com/signalfx/gdi-specification/pull/277): - already done
  - Deprecate `splunk.distro.version`,
  - Change `telemetry.auto.version` to `telemetry.distro.version`,
  - Add `telemetry.distro.name` resource attribute.
- Relax name restrictions to include Cisco/AppDynamics. - N/A
  [#308](https://github.com/signalfx/gdi-specification/pull/308)

### Semantic Conventions

#### Enhancements

- Deprecate `text` format for `profiling.data.format`. - not used in this repo/already removed from distro
  [#285](https://github.com/signalfx/gdi-specification/pull/285)
