### PR TITLE
[snapshots] implement snapshots collection

### DIFF
--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/ConfigurationKeys.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/ConfigurationKeys.cs
@@ -58,6 +58,24 @@ internal static class ConfigurationKeys
             /// </summary>
             public const string ProfilerLogsEndpoint = "SPLUNK_PROFILER_LOGS_ENDPOINT";
         }
+
+        public static class Snapshots
+        {
+            /// <summary>
+            /// Configuration key for enabling snapshots.
+            /// </summary>
+            public const string Enabled = "SPLUNK_SNAPSHOT_PROFILER_ENABLED";
+
+            /// <summary>
+            /// Configuration key for snapshots sampling interval.
+            /// </summary>
+            public const string SamplingInterval = "SPLUNK_SNAPSHOT_SAMPLING_INTERVAL";
+
+            /// <summary>
+            /// Configuration key for snapshots sampling ratio.
+            /// </summary>
+            public const string SelectionRate = "SPLUNK_SNAPSHOT_SELECTION_RATE";
+        }
 #endif
     }
 

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/ContinuousProfiler/GdiProfilingConventions.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/ContinuousProfiler/GdiProfilingConventions.cs
@@ -73,6 +73,18 @@ internal static class GdiProfilingConventions
                     }
                 };
             }
+
+            public static KeyValue InstrumentationSource(string source)
+            {
+                return new KeyValue
+                {
+                    Key = "profiling.instrumentation.source",
+                    Value = new AnyValue
+                    {
+                        StringValue = source
+                    }
+                };
+            }
         }
     }
 }

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/ContinuousProfiler/SampleNativeFormatParser.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/ContinuousProfiler/SampleNativeFormatParser.cs
@@ -207,6 +207,64 @@ internal static class SampleNativeFormatParser
         return allocationSamples;
     }
 
+    internal static List<ThreadSample> ParseSelectiveSamplerSamples(byte[] buffer, int read)
+    {
+        var selectiveSamplerSamples = new List<ThreadSample>();
+        var position = 0;
+
+        uint threadIndex = 0;
+
+        var codeDictionary = new Dictionary<int, string>();
+
+        try
+        {
+            while (position < read)
+            {
+                var operationCode = buffer[position++];
+
+                if (operationCode == OpCodes.SelectiveSampleBatchStart)
+                {
+                    // each batch has independently coded strings
+                    codeDictionary.Clear();
+                }
+                else if (operationCode == OpCodes.SelectiveSample)
+                {
+                    var timestampMillis = ReadInt64(buffer, ref position);
+                    var threadName = ReadString(buffer, ref position);
+                    var traceIdHigh = ReadInt64(buffer, ref position);
+                    var traceIdLow = ReadInt64(buffer, ref position);
+                    var spanId = ReadInt64(buffer, ref position);
+
+                    var threadSample = new ThreadSample(
+                        new ThreadSample.Time(timestampMillis),
+                        spanId,
+                        traceIdHigh,
+                        traceIdLow,
+                        threadName,
+                        threadIndex++);
+
+                    var code = ReadShort(buffer, ref position);
+
+                    ReadStackFrames(code, threadSample, codeDictionary, buffer, ref position);
+                    selectiveSamplerSamples.Add(threadSample);
+                }
+                else if (operationCode == OpCodes.SelectiveSampleBatchEnd)
+                {
+                }
+                else
+                {
+                    position = read + 1;
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e + "Unexpected error while parsing selected threads samples.");
+        }
+
+        return selectiveSamplerSamples;
+    }
+
     private static string ReadString(byte[] buffer, ref int position)
     {
         var length = ReadShort(buffer, ref position);
@@ -311,6 +369,21 @@ internal static class SampleNativeFormatParser
         /// Marks the start of an allocation sample, see THREAD_SAMPLES_ALLOCATION_SAMPLE on native code.
         /// </summary>
         public const byte AllocationSample = 0x08;
+
+        /// <summary>
+        /// Marks the start of a selective thread sample, see kSelectiveSample on native code.
+        /// </summary>
+        public const byte SelectiveSample = 0x09;
+
+        /// <summary>
+        /// Marks the start of a selective thread samples batch, see kSelectedThreadsStartBatch on native code.
+        /// </summary>
+        public const byte SelectiveSampleBatchStart = 0x0A;
+
+        /// <summary>
+        /// Marks the end of a selective thread samples batch, see kSelectedThreadsEndBatch on native code.
+        /// </summary>
+        public const byte SelectiveSampleBatchEnd = 0x0B;
     }
 }
 

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/ContinuousProfiler/SampleProcessor.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/ContinuousProfiler/SampleProcessor.cs
@@ -31,15 +31,28 @@ internal class SampleProcessor
     private readonly KeyValue _format;
     private readonly KeyValue _profilingDataTypeCpu;
     private readonly KeyValue _profilingDataTypeAllocation;
-    private readonly TimeSpan _threadSamplingPeriod;
+    private readonly KeyValue _instrumentationSource;
+    private uint _selectedSamplingPeriod;
+    private uint _continuousSamplingPeriod;
 
-    public SampleProcessor(TimeSpan threadSamplingPeriod)
+    public SampleProcessor()
     {
         _format = GdiProfilingConventions.LogRecord.Attributes.Format("pprof-gzip-base64");
         _profilingDataTypeCpu = GdiProfilingConventions.LogRecord.Attributes.Type("cpu");
         _profilingDataTypeAllocation = GdiProfilingConventions.LogRecord.Attributes.Type("allocation");
+        _instrumentationSource = GdiProfilingConventions.LogRecord.Attributes.InstrumentationSource("snapshot");
+    }
 
-        _threadSamplingPeriod = threadSamplingPeriod;
+    public uint ContinuousSamplingPeriod
+    {
+        get => Volatile.Read(ref _continuousSamplingPeriod);
+        set => Volatile.Write(ref _continuousSamplingPeriod, value);
+    }
+
+    public uint SelectedSamplingPeriod
+    {
+        get => Volatile.Read(ref _selectedSamplingPeriod);
+        set => Volatile.Write(ref _selectedSamplingPeriod, value);
     }
 
     public LogRecord? ProcessThreadSamples(List<ThreadSample>? threadSamples)
@@ -49,7 +62,7 @@ internal class SampleProcessor
             return null;
         }
 
-        var cpuProfile = BuildCpuProfile(threadSamples);
+        var cpuProfile = BuildCpuProfile(threadSamples, (long)ContinuousSamplingPeriod!);
         var totalFrameCount = CountFrames(threadSamples);
 
         return BuildLogRecord(cpuProfile, _profilingDataTypeCpu, totalFrameCount);
@@ -66,6 +79,21 @@ internal class SampleProcessor
         var totalFrameCount = CountFrames(allocationSamples);
 
         return BuildLogRecord(allocationProfile, _profilingDataTypeAllocation, totalFrameCount);
+    }
+
+    public LogRecord? ProcessSelectedSamples(List<ThreadSample> selectedSamples)
+    {
+        if (selectedSamples == null || selectedSamples.Count < 1)
+        {
+            return null;
+        }
+
+        var selectedSampleProfile = BuildCpuProfile(selectedSamples, (long)SelectedSamplingPeriod!);
+        var totalFrameCount = CountFrames(selectedSamples);
+
+        var processSelectedSamples = BuildLogRecord(selectedSampleProfile, _profilingDataTypeCpu, totalFrameCount);
+        processSelectedSamples.Attributes.Add(_instrumentationSource);
+        return processSelectedSamples;
     }
 
     private static int CountFrames(List<AllocationSample> samples)
@@ -140,7 +168,7 @@ internal class SampleProcessor
         return Serialize(pprof.Profile);
     }
 
-    private string BuildCpuProfile(List<ThreadSample> threadSamples)
+    private string BuildCpuProfile(List<ThreadSample> threadSamples, long valueTotalMilliseconds)
     {
         var pprof = new Pprof();
         for (var index = 0; index < threadSamples.Count; index++)
@@ -148,7 +176,7 @@ internal class SampleProcessor
             var threadSample = threadSamples[index];
             var sampleBuilder = CreateSampleBuilder(pprof, threadSample);
 
-            pprof.AddLabel(sampleBuilder, "source.event.period", (long)_threadSamplingPeriod.TotalMilliseconds);
+            pprof.AddLabel(sampleBuilder, "source.event.period", valueTotalMilliseconds);
             pprof.Profile.Samples.Add(sampleBuilder.Build());
         }
 

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Plugin.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Plugin.cs
@@ -14,9 +14,15 @@
 // limitations under the License.
 // </copyright>
 
+using OpenTelemetry;
+using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
 using Splunk.OpenTelemetry.AutoInstrumentation.Logging;
+#if NET
+using Splunk.OpenTelemetry.AutoInstrumentation.Snapshots;
+#endif
 
 #if NETFRAMEWORK
 using OpenTelemetry.Instrumentation.AspNet;
@@ -32,12 +38,21 @@ namespace Splunk.OpenTelemetry.AutoInstrumentation;
 /// </summary>
 public class Plugin
 {
-    private static readonly PluginSettings Settings = PluginSettings.FromDefaultSources();
+#pragma warning disable SA1401
+    internal static Func<PluginSettings> DefaultSettingsFactory = PluginSettings.FromDefaultSources;
+#pragma warning restore SA1401
+    private static readonly Lazy<PluginSettings> SettingsFactory = new(() => DefaultSettingsFactory());
+
     private static readonly ILogger Log = new Logger();
+#if NET
+    private static PprofInOtlpLogsExporter? _pprofInOtlpLogsExporter;
+#endif
 
     private readonly Metrics _metrics = new(Settings);
     private readonly Traces _traces = new(Settings);
     private readonly Sdk _sdk = new();
+
+    private static PluginSettings Settings => SettingsFactory.Value;
 
     /// <summary>
     /// Configures Sdk
@@ -101,6 +116,23 @@ public class Plugin
     public void ConfigureTracesOptions(AspNetCoreTraceInstrumentationOptions options)
     {
         _traces.ConfigureTracesOptions(options);
+        if (Settings.SnapshotsEnabled)
+        {
+            options.EnrichWithHttpRequest += (activity, _) =>
+            {
+                if (!SnapshotVolumeDetector.IsLoud(Baggage.Current))
+                {
+                    return;
+                }
+
+                if (activity.IsEntry())
+                {
+                    activity.MarkLoud();
+                }
+
+                CurrentThreadSampler.Instance.StartSampling();
+            };
+        }
     }
 
 #endif
@@ -116,18 +148,82 @@ public class Plugin
         var threadSamplingInterval = Settings.CpuProfilerCallStackInterval;
         var allocationSamplingEnabled = Settings.MemoryProfilerEnabled;
         const uint maxMemorySamplesPerMinute = 200u;
-        var exportInterval = TimeSpan.FromMilliseconds(500); // it is half of the shortest possible thread sampling interval
-        var exportTimeout = TimeSpan.FromSeconds(3);
+        var exportInterval = GetDefaultSampleExportInterval();
+        var exportTimeout = GetDefaultSampleExportTimeout();
 
-        var sampleProcessor = new SampleProcessor(TimeSpan.FromMilliseconds(threadSamplingInterval));
+        var pprofInOtlpLogsExporter = GetPprofInOtlpLogsExporter();
+        pprofInOtlpLogsExporter.SampleProcessor.ContinuousSamplingPeriod = threadSamplingInterval;
 
-        var logSender = new OtlpHttpLogSender(Settings.ProfilerLogsEndpoint);
-
-        var sampleExporter = new SampleExporter(logSender);
-
-        object continuousProfilerExporter = new PprofInOtlpLogsExporter(sampleProcessor, sampleExporter);
-
-        return Tuple.Create(threadSamplingEnabled, threadSamplingInterval, allocationSamplingEnabled, maxMemorySamplesPerMinute, exportInterval, exportTimeout, continuousProfilerExporter);
+        return Tuple.Create(threadSamplingEnabled, threadSamplingInterval, allocationSamplingEnabled, maxMemorySamplesPerMinute, exportInterval, exportTimeout, (object)pprofInOtlpLogsExporter);
     }
+
+    /// <summary>
+    /// Returns selective sampling configuration.
+    /// </summary>
+    /// <returns>(frequentSamplingInterval, exportInterval, exportTimeout, pprofInOtlpLogsExporter) or null.</returns>
+    public Tuple<uint, TimeSpan, TimeSpan, object?>? GetSelectiveSamplingConfiguration()
+    {
+#if NET
+        if (Settings.SnapshotsEnabled)
+        {
+            var frequentSamplingInterval = (uint)Settings.SnapshotsSamplingInterval;
+            var pprofInOtlpLogsExporter = GetPprofInOtlpLogsExporter();
+            pprofInOtlpLogsExporter.SampleProcessor.SelectedSamplingPeriod = frequentSamplingInterval;
+            var exportInterval = GetDefaultSampleExportInterval();
+            var exportTimeout = GetDefaultSampleExportTimeout();
+            return Tuple.Create(frequentSamplingInterval, exportInterval, exportTimeout, (object)pprofInOtlpLogsExporter)!;
+        }
+#endif
+
+        return null;
+    }
+
+    /// <summary>
+    /// Modify SDK config.
+    /// </summary>
+    /// <param name="builder">TracerProviderBuilder instance to customize.</param>
+    /// <returns>TracerProviderBuilder instance for chaining.</returns>
+    public TracerProviderBuilder BeforeConfigureTracerProvider(TracerProviderBuilder builder)
+    {
+#if NET
+        if (Settings.SnapshotsEnabled)
+        {
+            var currentPropagator = Propagators.DefaultTextMapPropagator;
+            // Ensure baggage propagator is configured.
+            if (currentPropagator.Fields == null || !currentPropagator.Fields.Contains("baggage"))
+            {
+                throw new NotSupportedException("Collecting snapshots requires baggage propagator usage.");
+            }
+
+            global::OpenTelemetry.Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator([currentPropagator, new SnapshotVolumePropagator(new ProbabilisticVolumeSelector(Settings.SnapshotsSelectionRate))]));
+            builder.AddInstrumentation(new AsyncSuspensionTracker(CurrentThreadSampler.Instance));
+        }
+
+        return builder;
+    }
+
+    private static TimeSpan GetDefaultSampleExportTimeout()
+    {
+        return TimeSpan.FromSeconds(5);
+    }
+
+    private static TimeSpan GetDefaultSampleExportInterval()
+    {
+        // it is half of the shortest possible thread sampling interval
+        return TimeSpan.FromMilliseconds(500);
+    }
+
+    private static PprofInOtlpLogsExporter GetPprofInOtlpLogsExporter()
+    {
+        _pprofInOtlpLogsExporter ??= CreatePprofInOtlpLogsExporter();
+        return _pprofInOtlpLogsExporter;
+    }
+
+    private static PprofInOtlpLogsExporter CreatePprofInOtlpLogsExporter()
+    {
+        return new PprofInOtlpLogsExporter(new SampleProcessor(), new SampleExporter(new OtlpHttpLogSender(Settings.ProfilerLogsEndpoint)));
+    }
+#endif
+
 #endif
 }

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/PluginSettings.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/PluginSettings.cs
@@ -40,6 +40,9 @@ internal class PluginSettings
 
 #if NET
         CpuProfilerEnabled = source.GetBool(ConfigurationKeys.Splunk.AlwaysOnProfiler.CpuProfilerEnabled) ?? false;
+        SnapshotsEnabled = source.GetBool(ConfigurationKeys.Splunk.Snapshots.Enabled) ?? false;
+        SnapshotsSamplingInterval = source.GetInt32(ConfigurationKeys.Splunk.Snapshots.SamplingInterval) ?? 50;
+        SnapshotsSelectionRate = source.GetDouble(ConfigurationKeys.Splunk.Snapshots.SelectionRate) ?? 0.01;
         MemoryProfilerEnabled = source.GetBool(ConfigurationKeys.Splunk.AlwaysOnProfiler.MemoryProfilerEnabled) ?? false;
         var callStackInterval = source.GetInt32(ConfigurationKeys.Splunk.AlwaysOnProfiler.CallStackInterval) ?? 10000;
         CpuProfilerCallStackInterval = callStackInterval < 0 ? 10000u : (uint)callStackInterval;
@@ -47,6 +50,12 @@ internal class PluginSettings
         ProfilerLogsEndpoint = GetProfilerLogsEndpoints(source, otlpEndpoint == null ? null : new Uri(otlpEndpoint));
 #endif
     }
+
+    public int SnapshotsSamplingInterval { get; set; }
+
+    public bool SnapshotsEnabled { get; set; }
+
+    public double SnapshotsSelectionRate { get; set; }
 
     public string Realm { get; }
 

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/AsyncSuspensionTracker.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/AsyncSuspensionTracker.cs
@@ -1,0 +1,117 @@
+﻿// <copyright file="AsyncSuspensionTracker.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET
+
+using System.Diagnostics;
+using System.Reflection;
+using OpenTelemetry;
+using Splunk.OpenTelemetry.AutoInstrumentation.Logging;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Snapshots
+{
+    internal class AsyncSuspensionTracker : IDisposable
+    {
+        private static readonly ILogger Log = new Logger();
+
+        private static AsyncLocal<Activity?>? _supportingActivityAsyncLocal;
+        private readonly CurrentThreadSampler _currentThreadSampler;
+        private readonly Func<ActivityListener?> _listenerExtractorFactory;
+        private ActivityListener? _autoInstrumentationActivityListener;
+
+        public AsyncSuspensionTracker(CurrentThreadSampler currentThreadSampler)
+            : this(currentThreadSampler, TryExtractAutoInstrumentationActivityListener)
+        {
+        }
+
+        internal AsyncSuspensionTracker(CurrentThreadSampler currentThreadSampler, Func<ActivityListener?> listenerExtractorFactory)
+        {
+            _supportingActivityAsyncLocal = new AsyncLocal<Activity?>(ActivityChanged);
+            _currentThreadSampler = currentThreadSampler;
+            _listenerExtractorFactory = listenerExtractorFactory;
+            Activity.CurrentChanged += ActivityCurrentChanged;
+        }
+
+        public void Dispose()
+        {
+            Activity.CurrentChanged -= ActivityCurrentChanged;
+        }
+
+        private static void ActivityCurrentChanged(object? sender, ActivityChangedEventArgs e)
+        {
+            if (_supportingActivityAsyncLocal != null)
+            {
+                _supportingActivityAsyncLocal.Value = e.Current;
+            }
+        }
+
+        private static ActivityListener? TryExtractAutoInstrumentationActivityListener()
+        {
+            try
+            {
+                var tracerProviderSdk =
+                    Type.GetType("OpenTelemetry.AutoInstrumentation.Instrumentation, OpenTelemetry.AutoInstrumentation")!
+                        .GetField("_tracerProvider", BindingFlags.Static | BindingFlags.NonPublic)!
+                        .GetValue(null);
+                return (ActivityListener)tracerProviderSdk!
+                    .GetType()
+                    .GetField("listener", BindingFlags.Instance | BindingFlags.NonPublic)!
+                    .GetValue(tracerProviderSdk)!;
+            }
+            catch (Exception e)
+            {
+                Log.Error(e, "Failed to extract listener from OpenTelemetry.AutoInstrumentation");
+            }
+
+            return null;
+        }
+
+        private void ActivityChanged(AsyncLocalValueChangedArgs<Activity?> sender)
+        {
+            var currentActivity = sender.CurrentValue;
+            if (currentActivity is not null && !currentActivity.IsStopped && IsFromSubscribedSource(currentActivity))
+            {
+                if (SnapshotVolumeDetector.IsLoud(Baggage.Current))
+                {
+                    if (currentActivity.IsEntry())
+                    {
+                        currentActivity.MarkLoud();
+                    }
+
+                    _currentThreadSampler.StartSampling();
+                }
+                else
+                {
+                    _currentThreadSampler.StopSampling();
+                }
+            }
+            else
+            {
+                _currentThreadSampler.StopSampling();
+            }
+        }
+
+        private bool IsFromSubscribedSource(Activity currentActivity)
+        {
+            // Tracking (subscription to ActivityChanged event) starts early (suspension tracker is added as instrumentation, in BeforeConfigureTracerProvider).
+            // It is possible to get a callback before autoinstrumentation creates TracerProviderSdk instance.
+            _autoInstrumentationActivityListener ??= _listenerExtractorFactory();
+            return _autoInstrumentationActivityListener != null && _autoInstrumentationActivityListener.ShouldListenTo!(currentActivity.Source);
+        }
+    }
+}
+#endif
+

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/CurrentThreadSampler.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/CurrentThreadSampler.cs
@@ -1,0 +1,47 @@
+﻿// <copyright file="CurrentThreadSampler.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Snapshots
+{
+    internal class CurrentThreadSampler
+    {
+        private static readonly Lazy<CurrentThreadSampler> InstanceFactory = new(() => new CurrentThreadSampler(NativeMethods.StartSamplingDelegate, NativeMethods.StopSamplingDelegate));
+
+        private readonly Action? _startSamplingDelegate;
+        private readonly Action? _stopSamplingDelegate;
+
+        internal CurrentThreadSampler(Action? startSamplingDelegate, Action? stopSamplingDelegate)
+        {
+            _startSamplingDelegate = startSamplingDelegate;
+            _stopSamplingDelegate = stopSamplingDelegate;
+        }
+
+        public static CurrentThreadSampler Instance => InstanceFactory.Value;
+
+        public void StartSampling()
+        {
+            _startSamplingDelegate?.Invoke();
+        }
+
+        public void StopSampling()
+        {
+            _stopSamplingDelegate?.Invoke();
+        }
+    }
+}
+#endif

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/ISnapshotSelector.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/ISnapshotSelector.cs
@@ -1,0 +1,33 @@
+﻿// <copyright file="ISnapshotSelector.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Snapshots
+{
+    /// <summary>
+    /// Represents snapshot selector.
+    /// </summary>
+    internal interface ISnapshotSelector
+    {
+        /// <summary>
+        /// Method for selecting trace for capturing snapshots.
+        /// </summary>
+        /// <returns>Returns <c>true</c> if snapshots should be captured for the trace; otherwise, <c>false</c>.</returns>
+        public bool Select();
+    }
+}
+#endif

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/NativeMethods.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/NativeMethods.cs
@@ -1,0 +1,55 @@
+﻿// <copyright file="NativeMethods.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET
+
+using System.Reflection;
+using Splunk.OpenTelemetry.AutoInstrumentation.Logging;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Snapshots
+{
+    internal static class NativeMethods
+    {
+        private static readonly ILogger Log = new Logger();
+
+        static NativeMethods()
+        {
+            try
+            {
+                var nativeMethodsType = Type.GetType("OpenTelemetry.AutoInstrumentation.NativeMethods, OpenTelemetry.AutoInstrumentation");
+                if (nativeMethodsType == null)
+                {
+                    throw new Exception("OpenTelemetry.AutoInstrumentation.NativeMethods could not be found.");
+                }
+
+                var startMethod = nativeMethodsType.GetMethod("SelectiveSamplingStart", BindingFlags.Static | BindingFlags.Public, null, [], null);
+                var stopMethod = nativeMethodsType!.GetMethod("SelectiveSamplingStop", BindingFlags.Static | BindingFlags.Public, null, [], null);
+
+                StartSamplingDelegate = (Action)Delegate.CreateDelegate(typeof(Action), startMethod!);
+                StopSamplingDelegate = (Action)Delegate.CreateDelegate(typeof(Action), stopMethod!);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to initialize sampling methods");
+            }
+        }
+
+        public static Action? StopSamplingDelegate { get; }
+
+        public static Action? StartSamplingDelegate { get; }
+    }
+}
+#endif

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/ProbabilisticVolumeSelector.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/ProbabilisticVolumeSelector.cs
@@ -1,0 +1,37 @@
+﻿// <copyright file="ProbabilisticVolumeSelector.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Snapshots
+{
+    internal class ProbabilisticVolumeSelector : ISnapshotSelector
+    {
+        private readonly double _ratio;
+        private readonly Random _random = new();
+
+        public ProbabilisticVolumeSelector(double ratio)
+        {
+            _ratio = ratio;
+        }
+
+        public bool Select()
+        {
+            return _random.NextDouble() <= _ratio;
+        }
+    }
+}
+#endif

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/SnapshotActivityExtensions.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/SnapshotActivityExtensions.cs
@@ -1,0 +1,36 @@
+﻿// <copyright file="SnapshotActivityExtensions.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET
+
+using System.Diagnostics;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Snapshots
+{
+    internal static class SnapshotActivityExtensions
+    {
+        public static void MarkLoud(this Activity activity)
+        {
+            activity.SetTag(SnapshotConstants.SplunkSnapshotProfilingAttributeName, true);
+        }
+
+        public static bool IsEntry(this Activity activity)
+        {
+            return activity.Parent is null || activity.HasRemoteParent;
+        }
+    }
+}
+#endif

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/SnapshotConstants.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/SnapshotConstants.cs
@@ -1,0 +1,27 @@
+﻿// <copyright file="SnapshotConstants.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Snapshots
+{
+    internal static class SnapshotConstants
+    {
+        public const string VolumeBaggageKeyName = "splunk.trace.snapshot.volume";
+        public const string SplunkSnapshotProfilingAttributeName = "splunk.snapshot.profiling";
+    }
+}
+#endif

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/SnapshotVolumeDetector.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/SnapshotVolumeDetector.cs
@@ -1,0 +1,33 @@
+﻿// <copyright file="SnapshotVolumeDetector.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET
+
+using OpenTelemetry;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Snapshots
+{
+    internal static class SnapshotVolumeDetector
+    {
+        public static bool IsLoud(Baggage baggage)
+        {
+            var volume = baggage.GetBaggage(SnapshotConstants.VolumeBaggageKeyName);
+
+            return volume != null && volume.Equals("highest", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}
+#endif

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/SnapshotVolumePropagator.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/SnapshotVolumePropagator.cs
@@ -1,0 +1,71 @@
+﻿// <copyright file="SnapshotVolumePropagator.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET
+
+using OpenTelemetry;
+using OpenTelemetry.Context.Propagation;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Snapshots
+{
+    internal class SnapshotVolumePropagator : TextMapPropagator
+    {
+        private readonly ISnapshotSelector _selector;
+
+        public SnapshotVolumePropagator(ISnapshotSelector selector)
+        {
+            _selector = selector;
+        }
+
+        public override ISet<string>? Fields { get; } = new HashSet<string>();
+
+        public override void Inject<T>(PropagationContext context, T carrier, Action<T, string, string> setter)
+        {
+        }
+
+        public override PropagationContext Extract<T>(PropagationContext context, T carrier, Func<T, string, IEnumerable<string>?> getter)
+        {
+            var baggage = context.Baggage;
+            var volume = baggage.GetBaggage(SnapshotConstants.VolumeBaggageKeyName);
+            if (volume != null || !IndicatesRootSpan(context))
+            {
+                return context;
+            }
+
+            var newVolume = _selector.Select() ? Volume.highest : Volume.off;
+
+            var updatedBaggage = context.Baggage.SetBaggage(SnapshotConstants.VolumeBaggageKeyName, GetStringValue(newVolume));
+            return new PropagationContext(context.ActivityContext, updatedBaggage);
+        }
+
+        private static bool IndicatesRootSpan(PropagationContext context)
+        {
+            return context.ActivityContext == default;
+        }
+
+        private static string GetStringValue(Volume newVolume)
+        {
+            return newVolume switch
+            {
+                Volume.highest => nameof(Volume.highest),
+                Volume.off => nameof(Volume.off),
+                Volume.unspecified => nameof(Volume.unspecified),
+                _ => newVolume.ToString()
+            };
+        }
+    }
+}
+#endif

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/Volume.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/Volume.cs
@@ -1,0 +1,31 @@
+﻿// <copyright file="Volume.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET
+
+// ReSharper disable InconsistentNaming
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Snapshots
+{
+    internal enum Volume
+    {
+#pragma warning disable SA1300
+        unspecified,
+        off,
+        highest
+#pragma warning restore SA1300
+    }
+}
+#endif

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/PluginTests.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/PluginTests.cs
@@ -1,0 +1,105 @@
+﻿// <copyright file="PluginTests.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET
+
+using System.Collections.Specialized;
+using System.Runtime.CompilerServices;
+using OpenTelemetry.Context.Propagation;
+using OpenTelemetry.Trace;
+using Splunk.OpenTelemetry.AutoInstrumentation.Configuration;
+using Splunk.OpenTelemetry.AutoInstrumentation.Pprof.Proto.Profile;
+using Splunk.OpenTelemetry.AutoInstrumentation.Snapshots;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Tests
+{
+    public class PluginTests
+    {
+        [Fact]
+        public void WhenSnapshotsAreEnabledAndBaggagePropagatorIsNotConfigured_ExceptionIsThrown()
+        {
+            // Force SDK init.
+            _ = global::OpenTelemetry.Sdk.SuppressInstrumentation;
+
+            var defaultPropagator = global::OpenTelemetry.Context.Propagation.Propagators.DefaultTextMapPropagator;
+
+            // Replace default propagator which propagates baggage with something else.
+            global::OpenTelemetry.Sdk.SetDefaultTextMapPropagator(new TraceContextPropagator());
+
+            var defaultFactory = Plugin.DefaultSettingsFactory;
+
+            try
+            {
+                Plugin.DefaultSettingsFactory = () => new PluginSettings(new NameValueConfigurationSource(
+                    new NameValueCollection
+                    {
+                        ["SPLUNK_SNAPSHOT_PROFILER_ENABLED"] = "true"
+                    }));
+
+                var plugin = new Plugin();
+                var builder = new TracerProviderBuilderBase();
+                Assert.Throws<NotSupportedException>(() => plugin.BeforeConfigureTracerProvider(builder));
+            }
+            finally
+            {
+                global::OpenTelemetry.Sdk.SetDefaultTextMapPropagator(defaultPropagator);
+                Plugin.DefaultSettingsFactory = defaultFactory;
+            }
+        }
+
+        [Fact]
+        public void WhenSnapshotsAreEnabledAndBaggagePropagatorIsConfigured_SdkIsCustomized()
+        {
+            // Force SDK init.
+            _ = global::OpenTelemetry.Sdk.SuppressInstrumentation;
+
+            var defaultPropagator = global::OpenTelemetry.Context.Propagation.Propagators.DefaultTextMapPropagator;
+
+            var defaultFactory = Plugin.DefaultSettingsFactory;
+
+            try
+            {
+                Plugin.DefaultSettingsFactory = () => new PluginSettings(new NameValueConfigurationSource(
+                    new NameValueCollection
+                    {
+                        ["SPLUNK_SNAPSHOT_PROFILER_ENABLED"] = "true"
+                    }));
+
+                var plugin = new Plugin();
+                var builder = new TracerProviderBuilderBase();
+
+                plugin.BeforeConfigureTracerProvider(builder);
+
+                var configuredPropagator = Propagators.DefaultTextMapPropagator;
+                var propagators = GetPropagators((CompositeTextMapPropagator)configuredPropagator);
+
+                Assert.Equal(2, propagators.Count);
+
+                Assert.Equal(propagators[0], defaultPropagator);
+                Assert.IsType<SnapshotVolumePropagator>(propagators[1]);
+            }
+            finally
+            {
+                global::OpenTelemetry.Sdk.SetDefaultTextMapPropagator(defaultPropagator);
+                Plugin.DefaultSettingsFactory = defaultFactory;
+            }
+        }
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "propagators")]
+        private static extern ref IReadOnlyList<TextMapPropagator> GetPropagators(CompositeTextMapPropagator @this);
+    }
+}
+#endif

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/Snapshots/AsyncSuspensionTrackerTests.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/Snapshots/AsyncSuspensionTrackerTests.cs
@@ -1,0 +1,142 @@
+﻿// <copyright file="AsyncSuspensionTrackerTests.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET
+
+using System.Diagnostics;
+using OpenTelemetry;
+using Splunk.OpenTelemetry.AutoInstrumentation.Snapshots;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Tests.Snapshots
+{
+    public class AsyncSuspensionTrackerTests
+    {
+        [Fact]
+        public void IfActivityIsNotFromSubscribedSource_ShouldBeIgnored()
+        {
+            var defaultBaggage = Baggage.Current;
+            var startCalled = false;
+
+            try
+            {
+                Baggage.Current = Baggage.Create(new Dictionary<string, string> { ["splunk.trace.snapshot.volume"] = "highest" });
+
+                using var suspensionTrackerListener = CreateTestListener("Subscribed");
+                using var otherListener = CreateTestListener("NotSubscribed");
+
+                var sampler = new CurrentThreadSampler(() => startCalled = true, () => { });
+                // ReSharper disable once AccessToDisposedClosure
+                using var tracker = new AsyncSuspensionTracker(sampler, () => suspensionTrackerListener);
+
+                using var source = new ActivitySource("NotSubscribed");
+                ActivitySource.AddActivityListener(suspensionTrackerListener);
+
+                // Add another so that activity is created
+                ActivitySource.AddActivityListener(otherListener);
+
+                using var activity = source.StartActivity();
+
+                Assert.NotNull(activity);
+                Assert.False(startCalled);
+            }
+            finally
+            {
+                // restore defaults
+                Baggage.Current = defaultBaggage;
+            }
+        }
+
+        [Fact]
+        public void IfActivityIsFromSubscribedSource_ShouldBeSampled()
+        {
+            var defaultBaggage = Baggage.Current;
+
+            var startCalled = false;
+            var stopCalled = false;
+
+            try
+            {
+                Baggage.Current = Baggage.Create(new Dictionary<string, string> { ["splunk.trace.snapshot.volume"] = "highest" });
+
+                using var suspensionTrackerListener = CreateTestListener("Subscribed");
+
+                var sampler = new CurrentThreadSampler(() => startCalled = true, () => { stopCalled = true; });
+                // ReSharper disable once AccessToDisposedClosure
+                using var tracker = new AsyncSuspensionTracker(sampler, () => suspensionTrackerListener);
+
+                using var source = new ActivitySource("Subscribed");
+                ActivitySource.AddActivityListener(suspensionTrackerListener);
+
+                var activity = source.StartActivity();
+
+                Assert.NotNull(activity);
+                Assert.True(startCalled);
+                Assert.False(stopCalled);
+
+                activity.Stop();
+                Assert.True(stopCalled);
+            }
+            finally
+            {
+                // restore defaults
+                Baggage.Current = defaultBaggage;
+            }
+        }
+
+        [Fact]
+        public void IfActivityIsFromSubscribedSource_ButVolumeIsNotConsideredLoud_ShouldNotBeSampled()
+        {
+            var defaultBaggage = Baggage.Current;
+
+            var startCalled = false;
+
+            try
+            {
+                Baggage.Current = Baggage.Create(new Dictionary<string, string> { ["splunk.trace.snapshot.volume"] = "off" });
+
+                using var suspensionTrackerListener = CreateTestListener("Subscribed");
+
+                // ReSharper disable once AccessToDisposedClosure
+                var sampler = new CurrentThreadSampler(() => startCalled = true, () => { });
+                using var tracker = new AsyncSuspensionTracker(sampler, () => suspensionTrackerListener);
+
+                using var source = new ActivitySource("Subscribed");
+                ActivitySource.AddActivityListener(suspensionTrackerListener);
+
+                using var activity = source.StartActivity();
+
+                Assert.NotNull(activity);
+                Assert.False(startCalled);
+            }
+            finally
+            {
+                // restore defaults
+                Baggage.Current = defaultBaggage;
+            }
+        }
+
+        private static ActivityListener CreateTestListener(string subscribedSourceName)
+        {
+            return new ActivityListener
+            {
+                ShouldListenTo = activitySource => activitySource.Name == subscribedSourceName,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) =>
+                    ActivitySamplingResult.AllDataAndRecorded
+            };
+        }
+    }
+}
+#endif

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/Snapshots/SnapshotVolumeDetectorTests.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/Snapshots/SnapshotVolumeDetectorTests.cs
@@ -1,0 +1,51 @@
+﻿// <copyright file="SnapshotVolumeDetectorTests.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET
+
+using OpenTelemetry;
+using Splunk.OpenTelemetry.AutoInstrumentation.Snapshots;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Tests.Snapshots
+{
+    public class SnapshotVolumeDetectorTests
+    {
+        [Fact]
+        public void IfBaggageContainsVolumeKeyWithHighestValue_IsConsideredLoud()
+        {
+            var testBaggage = Baggage.Create(new Dictionary<string, string> { ["splunk.trace.snapshot.volume"] = "highest" });
+            var startSamplingDecision = SnapshotVolumeDetector.IsLoud(testBaggage);
+            Assert.True(startSamplingDecision);
+        }
+
+        [Fact]
+        public void IfBaggageContainsVolumeKeyWithOffValue_IsNotConsideredLoud()
+        {
+            var testBaggage = Baggage.Create(new Dictionary<string, string> { ["splunk.trace.snapshot.volume"] = "off" });
+            var startSamplingDecision = SnapshotVolumeDetector.IsLoud(testBaggage);
+            Assert.False(startSamplingDecision);
+        }
+
+        [Fact]
+        public void IfBaggageContainsNoVolumeKey_IsNotConsideredLoud()
+        {
+            var testBaggage = Baggage.Create(new Dictionary<string, string>());
+            var startSamplingDecision = SnapshotVolumeDetector.IsLoud(testBaggage);
+            Assert.False(startSamplingDecision);
+        }
+    }
+}
+#endif

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/Snapshots/SnapshotVolumePropagatorTests.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/Snapshots/SnapshotVolumePropagatorTests.cs
@@ -1,0 +1,77 @@
+﻿// <copyright file="SnapshotVolumePropagatorTests.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET
+
+using System.Diagnostics;
+using OpenTelemetry;
+using OpenTelemetry.Context.Propagation;
+using Splunk.OpenTelemetry.AutoInstrumentation.Snapshots;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Tests.Snapshots
+{
+    public class SnapshotVolumePropagatorTests
+    {
+        [Fact]
+        public void IfVolumeWasDecided_FollowTheDecision()
+        {
+            var propagator = new SnapshotVolumePropagator(new ProbabilisticVolumeSelector(0.0));
+
+            var dict = new Dictionary<string, object>();
+
+            var extractedContext = propagator.Extract(
+                new PropagationContext(default, Baggage.Create(new Dictionary<string, string> { ["splunk.trace.snapshot.volume"] = "highest" })),
+                dict,
+                (_, _) => throw new InvalidOperationException());
+
+            Assert.Equal("highest", extractedContext.Baggage.GetBaggage("splunk.trace.snapshot.volume"));
+        }
+
+        [Fact]
+        public void IgnoreNonRootSpans()
+        {
+            var propagator = new SnapshotVolumePropagator(new ProbabilisticVolumeSelector(1.0));
+
+            var dict = new Dictionary<string, object>();
+
+            var activityContext = new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded);
+            var extractedContext = propagator.Extract(
+                new PropagationContext(activityContext, Baggage.Create()),
+                dict,
+                (_, _) => throw new InvalidOperationException());
+
+            Assert.Empty(extractedContext.Baggage.GetBaggage());
+        }
+
+        [Theory]
+        [InlineData(1.0, "highest")]
+        [InlineData(0.0, "off")]
+        public void IfVolumeWasNotDecided_MakeADecision(double ratio, string expectedValue)
+        {
+            var propagator = new SnapshotVolumePropagator(new ProbabilisticVolumeSelector(ratio));
+
+            var dict = new Dictionary<string, object>();
+
+            var extractedContext = propagator.Extract(
+                new PropagationContext(default, default),
+                dict,
+                (_, _) => throw new InvalidOperationException());
+
+            Assert.Equal(expectedValue, extractedContext.Baggage.GetBaggage("splunk.trace.snapshot.volume"));
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Initial implementation of snapshots collection for .NET.
Follows similar approach to https://github.com/signalfx/splunk-otel-java/tree/main/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot.

Builds on top of changes proposed in https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/4225

At trace root, traces are selected for snapshotting based on configured percentage (trace-id based selector will be added in a followup PR).

Decision regarding volume is stored and propagated using baggage.

Plugin API is used to customize the `TracerProvider` created by the autoinstrumentation.

Main component of the feature is `AsyncSuspensionTracker` which is responsible for tracking span-thread association and starting and stopping sampling.