### PR TITLE
profiling: Make exporter HTTP client timeout configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ### Added
 
+- Added support for environmental variable `SPLUNK_PROFILER_EXPORT_TIMEOUT`.
+  It allows to set timeout in milliseconds. Default is `3000` ms.
+
 ### Changed
 
 ### Deprecated

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/ConfigurationKeys.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/ConfigurationKeys.cs
@@ -59,7 +59,7 @@ internal static class ConfigurationKeys
             public const string ProfilerLogsEndpoint = "SPLUNK_PROFILER_LOGS_ENDPOINT";
 
             /// <summary>
-            /// Configuration key for Profiler exporter HTTP Client Timeout. Defaults to 3s.
+            /// Configuration key for Profiler exporter HTTP Client Timeout (in ms). Defaults to 3000 ms.
             /// </summary>
             public const string ProfilerExportHTTPClientTimeout = "SPLUNK_PROFILER_EXPORTER_HTTP_CLIENT_TIMEOUT";
         }

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/ConfigurationKeys.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/ConfigurationKeys.cs
@@ -61,7 +61,7 @@ internal static class ConfigurationKeys
             /// <summary>
             /// Configuration key for Profiler exporter HTTP Client Timeout (in ms). Defaults to 3000 ms.
             /// </summary>
-            public const string ProfilerExportHTTPClientTimeout = "SPLUNK_PROFILER_EXPORTER_HTTP_CLIENT_TIMEOUT";
+            public const string ProfilerExportTimeout = "SPLUNK_PROFILER_EXPORT_TIMEOUT";
         }
 #endif
     }

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/ConfigurationKeys.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/ConfigurationKeys.cs
@@ -57,6 +57,11 @@ internal static class ConfigurationKeys
             /// Configuration key for endpoint where profiling data is sent. Defaults to the value in `OTLP_EXPORTER_OTLP_ENDPOINT`.
             /// </summary>
             public const string ProfilerLogsEndpoint = "SPLUNK_PROFILER_LOGS_ENDPOINT";
+
+            /// <summary>
+            /// Configuration key for Profiler exporter HTTP Client Timeout. Defaults to 3s.
+            /// </summary>
+            public const string ProfilerExportHTTPClientTimeout = "SPLUNK_PROFILER_EXPORTER_HTTP_CLIENT_TIMEOUT";
         }
 #endif
     }

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Plugin.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Plugin.cs
@@ -117,7 +117,7 @@ public class Plugin
         var allocationSamplingEnabled = Settings.MemoryProfilerEnabled;
         const uint maxMemorySamplesPerMinute = 200u;
         var exportInterval = TimeSpan.FromMilliseconds(500); // it is half of the shortest possible thread sampling interval
-        var exportTimeout = TimeSpan.FromSeconds(Settings.ProfilerHttpClientTimeout);
+        var exportTimeout = TimeSpan.FromMilliseconds(Settings.ProfilerHttpClientTimeout);
 
         var sampleProcessor = new SampleProcessor(TimeSpan.FromMilliseconds(threadSamplingInterval));
 

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Plugin.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Plugin.cs
@@ -117,7 +117,7 @@ public class Plugin
         var allocationSamplingEnabled = Settings.MemoryProfilerEnabled;
         const uint maxMemorySamplesPerMinute = 200u;
         var exportInterval = TimeSpan.FromMilliseconds(500); // it is half of the shortest possible thread sampling interval
-        var exportTimeout = TimeSpan.FromSeconds(3);
+        var exportTimeout = TimeSpan.FromSeconds(Settings.ProfilerHttpClientTimeout);
 
         var sampleProcessor = new SampleProcessor(TimeSpan.FromMilliseconds(threadSamplingInterval));
 

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/PluginSettings.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/PluginSettings.cs
@@ -43,7 +43,7 @@ internal class PluginSettings
         MemoryProfilerEnabled = source.GetBool(ConfigurationKeys.Splunk.AlwaysOnProfiler.MemoryProfilerEnabled) ?? false;
         var callStackInterval = source.GetInt32(ConfigurationKeys.Splunk.AlwaysOnProfiler.CallStackInterval) ?? 10000;
         CpuProfilerCallStackInterval = callStackInterval < 0 ? 10000u : (uint)callStackInterval;
-        var httpClientTimeout = source.GetInt32(ConfigurationKeys.Splunk.AlwaysOnProfiler.ProfilerExportHTTPClientTimeout) ?? 3000;
+        var httpClientTimeout = source.GetInt32(ConfigurationKeys.Splunk.AlwaysOnProfiler.ProfilerExportTimeout) ?? 3000;
         ProfilerHttpClientTimeout = (uint)httpClientTimeout;
 
         ProfilerLogsEndpoint = GetProfilerLogsEndpoints(source, otlpEndpoint == null ? null : new Uri(otlpEndpoint));

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/PluginSettings.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/PluginSettings.cs
@@ -43,7 +43,7 @@ internal class PluginSettings
         MemoryProfilerEnabled = source.GetBool(ConfigurationKeys.Splunk.AlwaysOnProfiler.MemoryProfilerEnabled) ?? false;
         var callStackInterval = source.GetInt32(ConfigurationKeys.Splunk.AlwaysOnProfiler.CallStackInterval) ?? 10000;
         CpuProfilerCallStackInterval = callStackInterval < 0 ? 10000u : (uint)callStackInterval;
-        var httpClientTimeout = source.GetInt32(ConfigurationKeys.Splunk.AlwaysOnProfiler.ProfilerExportHTTPClientTimeout) ?? 3;
+        var httpClientTimeout = source.GetInt32(ConfigurationKeys.Splunk.AlwaysOnProfiler.ProfilerExportHTTPClientTimeout) ?? 3000;
         ProfilerHttpClientTimeout = (uint)httpClientTimeout;
 
         ProfilerLogsEndpoint = GetProfilerLogsEndpoints(source, otlpEndpoint == null ? null : new Uri(otlpEndpoint));

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/PluginSettings.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/PluginSettings.cs
@@ -43,6 +43,8 @@ internal class PluginSettings
         MemoryProfilerEnabled = source.GetBool(ConfigurationKeys.Splunk.AlwaysOnProfiler.MemoryProfilerEnabled) ?? false;
         var callStackInterval = source.GetInt32(ConfigurationKeys.Splunk.AlwaysOnProfiler.CallStackInterval) ?? 10000;
         CpuProfilerCallStackInterval = callStackInterval < 0 ? 10000u : (uint)callStackInterval;
+        var httpClientTimeout = source.GetInt32(ConfigurationKeys.Splunk.AlwaysOnProfiler.ProfilerExportHTTPClientTimeout) ?? 3;
+        ProfilerHttpClientTimeout = (uint)httpClientTimeout;
 
         ProfilerLogsEndpoint = GetProfilerLogsEndpoints(source, otlpEndpoint == null ? null : new Uri(otlpEndpoint));
 #endif
@@ -64,6 +66,8 @@ internal class PluginSettings
     public bool MemoryProfilerEnabled { get; }
 
     public Uri ProfilerLogsEndpoint { get; }
+
+    public uint ProfilerHttpClientTimeout { get; }
 #endif
 
     public static PluginSettings FromDefaultSources()

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/SettingsTests.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/SettingsTests.cs
@@ -41,7 +41,7 @@ namespace Splunk.OpenTelemetry.AutoInstrumentation.Tests
             Assert.False(settings.CpuProfilerEnabled);
             Assert.False(settings.MemoryProfilerEnabled);
             Assert.Equal(10000u, settings.CpuProfilerCallStackInterval);
-            Assert.Equal(3u, settings.ProfilerHttpClientTimeout);
+            Assert.Equal(3000u, settings.ProfilerHttpClientTimeout);
 #endif
         }
 
@@ -55,6 +55,7 @@ namespace Splunk.OpenTelemetry.AutoInstrumentation.Tests
             Environment.SetEnvironmentVariable(ConfigurationKeys.Splunk.AlwaysOnProfiler.CallStackInterval, null);
             Environment.SetEnvironmentVariable(ConfigurationKeys.Splunk.AlwaysOnProfiler.MemoryProfilerEnabled, null);
             Environment.SetEnvironmentVariable(ConfigurationKeys.Splunk.AlwaysOnProfiler.ProfilerLogsEndpoint, null);
+            Environment.SetEnvironmentVariable(ConfigurationKeys.Splunk.AlwaysOnProfiler.ProfilerExportHTTPClientTimeout, null);
 #endif
         }
     }

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/SettingsTests.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/SettingsTests.cs
@@ -41,6 +41,7 @@ namespace Splunk.OpenTelemetry.AutoInstrumentation.Tests
             Assert.False(settings.CpuProfilerEnabled);
             Assert.False(settings.MemoryProfilerEnabled);
             Assert.Equal(10000u, settings.CpuProfilerCallStackInterval);
+            Assert.Equal(3u, settings.ProfilerHttpClientTimeout);
 #endif
         }
 

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/SettingsTests.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/SettingsTests.cs
@@ -55,7 +55,7 @@ namespace Splunk.OpenTelemetry.AutoInstrumentation.Tests
             Environment.SetEnvironmentVariable(ConfigurationKeys.Splunk.AlwaysOnProfiler.CallStackInterval, null);
             Environment.SetEnvironmentVariable(ConfigurationKeys.Splunk.AlwaysOnProfiler.MemoryProfilerEnabled, null);
             Environment.SetEnvironmentVariable(ConfigurationKeys.Splunk.AlwaysOnProfiler.ProfilerLogsEndpoint, null);
-            Environment.SetEnvironmentVariable(ConfigurationKeys.Splunk.AlwaysOnProfiler.ProfilerExportHTTPClientTimeout, null);
+            Environment.SetEnvironmentVariable(ConfigurationKeys.Splunk.AlwaysOnProfiler.ProfilerExportTimeout, null);
 #endif
         }
     }

--- a/tools/MatrixHelper/SettingsData.cs
+++ b/tools/MatrixHelper/SettingsData.cs
@@ -60,6 +60,7 @@ internal static class SettingsData
             new("SPLUNK_PROFILER_MEMORY_ENABLED", "Activates memory profiling.", "false", "boolean", ProfilingCategory),
             new("SPLUNK_PROFILER_LOGS_ENDPOINT", "The collector endpoint for profiler logs.", "http://localhost:4318/v1/logs", "string", ProfilingCategory),
             new("SPLUNK_PROFILER_CALL_STACK_INTERVAL", "Frequency with which call stacks are sampled, in milliseconds.", "10000", "int", ProfilingCategory),
+            new("SPLUNK_PROFILER_EXPORT_TIMEOUT", "Export timeout, in milliseconds.", "3000", "int", ProfilingCategory),
 
             // trace propagation
             new("OTEL_PROPAGATORS", "Comma-separated list of propagators for the tracer. The default value is `tracecontext,baggage`. Supported values are `b3multi`, `b3`, `tracecontext`, and `baggage`.", "tracecontext,baggage", "string", TracePropagationCategory),


### PR DESCRIPTION
The PR proposes a new variable, `SPLUNK_PROFILER_EXPORTER_HTTP_CLIENT_TIMEOUT`,  to make the profiling data exporter client timeout configurable. Currently the timeout is hard coded to 3 seconds.