### PR TITLE
profiling: Add config options for export interval and memory sample collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 - Added support for environmental variable `SPLUNK_PROFILER_EXPORT_TIMEOUT`.
   It allows to set timeout in milliseconds. Default is `3000` ms.
+- Added support for environmental variable `SPLUNK_PROFILER_MAX_MEMORY_SAMPLES`.
+  It allows to set maximum memory samples collected per minute. The maximum value is 200.
+  Default is `200`.
+- Added support for environmental variable `SPLUNK_PROFILER_EXPORT_INTERVAL`.
+  It allows to set export interval in milliseconds. The minimum value is `500` ms.
+  Default is `500` ms.
 
 ### Changed
 

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/ConfigurationKeys.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/ConfigurationKeys.cs
@@ -62,6 +62,16 @@ internal static class ConfigurationKeys
             /// Configuration key for Profiler exporter HTTP Client Timeout (in ms). Defaults to 3000 ms.
             /// </summary>
             public const string ProfilerExportTimeout = "SPLUNK_PROFILER_EXPORT_TIMEOUT";
+
+            /// <summary>
+            /// Configuration key for Profiler maximum memory sample collected in a miniute. Defaults to 200, which is also the maximum.
+            /// </summary>
+            public const string ProfilerMaxMemorySamples = "SPLUNK_PROFILER_MAX_MEMORY_SAMPLES";
+
+            /// <summary>
+            /// Configuration key for Profiler exporter export interval (in ms). Defaults to 500 ms, which is also the minimum.
+            /// </summary>
+            public const string ProfilerExportInterval = "SPLUNK_PROFILER_EXPORT_INTERVAL";
         }
 #endif
     }

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Plugin.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Plugin.cs
@@ -115,8 +115,8 @@ public class Plugin
         var threadSamplingEnabled = Settings.CpuProfilerEnabled;
         var threadSamplingInterval = Settings.CpuProfilerCallStackInterval;
         var allocationSamplingEnabled = Settings.MemoryProfilerEnabled;
-        const uint maxMemorySamplesPerMinute = 200u;
-        var exportInterval = TimeSpan.FromMilliseconds(500); // it is half of the shortest possible thread sampling interval
+        var maxMemorySamplesPerMinute = Settings.MemoryProfilerMaxMemorySamplesPerMinute;
+        var exportInterval = TimeSpan.FromMilliseconds(Settings.ProfilerExportInterval);
         var exportTimeout = TimeSpan.FromMilliseconds(Settings.ProfilerHttpClientTimeout);
 
         var sampleProcessor = new SampleProcessor(TimeSpan.FromMilliseconds(threadSamplingInterval));

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/PluginSettings.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/PluginSettings.cs
@@ -43,8 +43,12 @@ internal class PluginSettings
         MemoryProfilerEnabled = source.GetBool(ConfigurationKeys.Splunk.AlwaysOnProfiler.MemoryProfilerEnabled) ?? false;
         var callStackInterval = source.GetInt32(ConfigurationKeys.Splunk.AlwaysOnProfiler.CallStackInterval) ?? 10000;
         CpuProfilerCallStackInterval = callStackInterval < 0 ? 10000u : (uint)callStackInterval;
+        var maxMemorySamplesPerMinute = source.GetInt32(ConfigurationKeys.Splunk.AlwaysOnProfiler.ProfilerMaxMemorySamples) ?? 200;
+        MemoryProfilerMaxMemorySamplesPerMinute = maxMemorySamplesPerMinute > 200 ? 200u : (uint)maxMemorySamplesPerMinute;
         var httpClientTimeout = source.GetInt32(ConfigurationKeys.Splunk.AlwaysOnProfiler.ProfilerExportTimeout) ?? 3000;
         ProfilerHttpClientTimeout = (uint)httpClientTimeout;
+        var exportInterval = source.GetInt32(ConfigurationKeys.Splunk.AlwaysOnProfiler.ProfilerExportInterval) ?? 500;
+        ProfilerExportInterval = exportInterval < 500 ? 500u : (uint)exportInterval;
 
         ProfilerLogsEndpoint = GetProfilerLogsEndpoints(source, otlpEndpoint == null ? null : new Uri(otlpEndpoint));
 #endif
@@ -63,11 +67,15 @@ internal class PluginSettings
 
     public uint CpuProfilerCallStackInterval { get; }
 
+    public uint MemoryProfilerMaxMemorySamplesPerMinute { get; }
+
     public bool MemoryProfilerEnabled { get; }
 
     public Uri ProfilerLogsEndpoint { get; }
 
     public uint ProfilerHttpClientTimeout { get; }
+
+    public uint ProfilerExportInterval { get; }
 #endif
 
     public static PluginSettings FromDefaultSources()

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/SettingsTests.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/SettingsTests.cs
@@ -42,6 +42,8 @@ namespace Splunk.OpenTelemetry.AutoInstrumentation.Tests
             Assert.False(settings.MemoryProfilerEnabled);
             Assert.Equal(10000u, settings.CpuProfilerCallStackInterval);
             Assert.Equal(3000u, settings.ProfilerHttpClientTimeout);
+            Assert.Equal(500u, settings.ProfilerExportInterval);
+            Assert.Equal(200u, settings.MemoryProfilerMaxMemorySamplesPerMinute);
 #endif
         }
 
@@ -56,6 +58,8 @@ namespace Splunk.OpenTelemetry.AutoInstrumentation.Tests
             Environment.SetEnvironmentVariable(ConfigurationKeys.Splunk.AlwaysOnProfiler.MemoryProfilerEnabled, null);
             Environment.SetEnvironmentVariable(ConfigurationKeys.Splunk.AlwaysOnProfiler.ProfilerLogsEndpoint, null);
             Environment.SetEnvironmentVariable(ConfigurationKeys.Splunk.AlwaysOnProfiler.ProfilerExportTimeout, null);
+            Environment.SetEnvironmentVariable(ConfigurationKeys.Splunk.AlwaysOnProfiler.ProfilerExportInterval, null);
+            Environment.SetEnvironmentVariable(ConfigurationKeys.Splunk.AlwaysOnProfiler.ProfilerMaxMemorySamples, null);
 #endif
         }
     }

--- a/tools/MatrixHelper/SettingsData.cs
+++ b/tools/MatrixHelper/SettingsData.cs
@@ -61,8 +61,8 @@ internal static class SettingsData
             new("SPLUNK_PROFILER_LOGS_ENDPOINT", "The collector endpoint for profiler logs.", "http://localhost:4318/v1/logs", "string", ProfilingCategory),
             new("SPLUNK_PROFILER_CALL_STACK_INTERVAL", "Frequency with which call stacks are sampled, in milliseconds.", "10000", "int", ProfilingCategory),
             new("SPLUNK_PROFILER_EXPORT_TIMEOUT", "Export timeout, in milliseconds.", "3000", "int", ProfilingCategory),
-            new("SPLUNK_PROFILER_MAX_MEMORY_SAMPLES", "Maximum memory samples collected per minute", "200", "int", ProfilingCategory),
-            new("SPLUNK_PROFILER_EXPORT_INTERVAL", "Export interval timeout, in milliseconds.", "500", "int", ProfilingCategory),
+            new("SPLUNK_PROFILER_MAX_MEMORY_SAMPLES", "Maximum memory samples collected per minute. Maximum value is 200.", "200", "int", ProfilingCategory),
+            new("SPLUNK_PROFILER_EXPORT_INTERVAL", "Export interval timeout, in milliseconds. Minimum value is 500.", "500", "int", ProfilingCategory),
 
             // trace propagation
             new("OTEL_PROPAGATORS", "Comma-separated list of propagators for the tracer. The default value is `tracecontext,baggage`. Supported values are `b3multi`, `b3`, `tracecontext`, and `baggage`.", "tracecontext,baggage", "string", TracePropagationCategory),

--- a/tools/MatrixHelper/SettingsData.cs
+++ b/tools/MatrixHelper/SettingsData.cs
@@ -61,6 +61,8 @@ internal static class SettingsData
             new("SPLUNK_PROFILER_LOGS_ENDPOINT", "The collector endpoint for profiler logs.", "http://localhost:4318/v1/logs", "string", ProfilingCategory),
             new("SPLUNK_PROFILER_CALL_STACK_INTERVAL", "Frequency with which call stacks are sampled, in milliseconds.", "10000", "int", ProfilingCategory),
             new("SPLUNK_PROFILER_EXPORT_TIMEOUT", "Export timeout, in milliseconds.", "3000", "int", ProfilingCategory),
+            new("SPLUNK_PROFILER_MAX_MEMORY_SAMPLES", "Maximum memory samples collected per minute", "200", "int", ProfilingCategory),
+            new("SPLUNK_PROFILER_EXPORT_INTERVAL", "Export interval timeout, in milliseconds.", "500", "int", ProfilingCategory),
 
             // trace propagation
             new("OTEL_PROPAGATORS", "Comma-separated list of propagators for the tracer. The default value is `tracecontext,baggage`. Supported values are `b3multi`, `b3`, `tracecontext`, and `baggage`.", "tracecontext,baggage", "string", TracePropagationCategory),


### PR DESCRIPTION
Make the profiling exporter configurable. Added the following options.

- `SPLUNK_PROFILER_MAX_MEMORY_SAMPLES` - It allows to set maximum memory samples collected per minute. The maximum value is 200. Default is `200`.
- `SPLUNK_PROFILER_EXPORT_INTERVAL` - It allows to set export interval in milliseconds. The minimum value is `500` ms. Default is `500` ms.