### PR TITLE
[snapshots] Updated implementation of snapshots collection

### DIFF
--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/ConfigurationKeys.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/ConfigurationKeys.cs
@@ -73,6 +73,24 @@ internal static class ConfigurationKeys
             /// </summary>
             public const string ProfilerExportInterval = "SPLUNK_PROFILER_EXPORT_INTERVAL";
         }
+
+        public static class Snapshots
+        {
+            /// <summary>
+            /// Configuration key for enabling snapshots.
+            /// </summary>
+            public const string Enabled = "SPLUNK_SNAPSHOT_PROFILER_ENABLED";
+
+            /// <summary>
+            /// Configuration key for snapshots sampling interval in ms.
+            /// </summary>
+            public const string SamplingIntervalMs = "SPLUNK_SNAPSHOT_SAMPLING_INTERVAL";
+
+            /// <summary>
+            /// Configuration key for snapshots sampling ratio.
+            /// </summary>
+            public const string SelectionRate = "SPLUNK_SNAPSHOT_SELECTION_RATE";
+        }
 #endif
     }
 

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/ContinuousProfiler/GdiProfilingConventions.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/ContinuousProfiler/GdiProfilingConventions.cs
@@ -73,6 +73,18 @@ internal static class GdiProfilingConventions
                     }
                 };
             }
+
+            public static KeyValue InstrumentationSource(string source)
+            {
+                return new KeyValue
+                {
+                    Key = "profiling.instrumentation.source",
+                    Value = new AnyValue
+                    {
+                        StringValue = source
+                    }
+                };
+            }
         }
     }
 }

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/ContinuousProfiler/ISampleExporter.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/ContinuousProfiler/ISampleExporter.cs
@@ -1,0 +1,35 @@
+// <copyright file="ISampleExporter.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET
+using Splunk.OpenTelemetry.AutoInstrumentation.Proto.Logs.V1;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.ContinuousProfiler
+{
+    /// <summary>
+    /// Exports log records containing samples.
+    /// </summary>
+    internal interface ISampleExporter
+    {
+        /// <summary>
+        /// Exports log record.
+        /// </summary>
+        /// <param name="logRecord">Log record containing samples.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        void Export(LogRecord logRecord, CancellationToken cancellationToken);
+    }
+}
+#endif

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/ContinuousProfiler/SampleExporter.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/ContinuousProfiler/SampleExporter.cs
@@ -26,7 +26,7 @@ namespace Splunk.OpenTelemetry.AutoInstrumentation.ContinuousProfiler;
 /// <summary>
 /// Exports Cpu/Allocation samples, accumulating LogRecords created by provided native buffer processors.
 /// </summary>
-internal class SampleExporter
+internal class SampleExporter : ISampleExporter
 {
     private static readonly ILogger Logger = new Logger();
 

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/ContinuousProfiler/ThreadSample.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/ContinuousProfiler/ThreadSample.cs
@@ -20,7 +20,14 @@ namespace Splunk.OpenTelemetry.AutoInstrumentation.ContinuousProfiler;
 
 internal class ThreadSample
 {
-    public ThreadSample(Time timestamp, long spanId, long traceIdHigh, long traceIdLow, string threadName, uint threadIndex)
+    public ThreadSample(
+        Time timestamp,
+        long spanId,
+        long traceIdHigh,
+        long traceIdLow,
+        string threadName,
+        uint threadIndex,
+        bool selectedForFrequentSampling)
     {
         Timestamp = timestamp;
         SpanId = spanId;
@@ -28,6 +35,7 @@ internal class ThreadSample
         TraceIdLow = traceIdLow;
         ThreadName = threadName;
         ThreadIndex = threadIndex;
+        SelectedForFrequentSampling = selectedForFrequentSampling;
     }
 
     public Time Timestamp { get; set; }
@@ -41,6 +49,8 @@ internal class ThreadSample
     public string ThreadName { get; set; }
 
     public uint ThreadIndex { get; set; }
+
+    public bool SelectedForFrequentSampling { get; set; }
 
     public IList<string> Frames { get; } = new List<string>();
 

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/CompositeSelector.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/CompositeSelector.cs
@@ -1,0 +1,39 @@
+﻿// <copyright file="CompositeSelector.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+#if NET
+
+using System.Diagnostics;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Snapshots
+{
+    internal class CompositeSelector : ISnapshotSelector
+    {
+        private readonly ProbabilisticVolumeSelector _probabilisticSelector;
+        private readonly TraceIdBasedSnapshotSelector _traceIdRatioBasedSelector;
+
+        public CompositeSelector(double ratio)
+        {
+            _probabilisticSelector = new ProbabilisticVolumeSelector(ratio);
+            _traceIdRatioBasedSelector = new TraceIdBasedSnapshotSelector(ratio);
+        }
+
+        public bool Select(ActivityContext context)
+        {
+            return _probabilisticSelector.Select(context) || _traceIdRatioBasedSelector.Select(context);
+        }
+    }
+}
+#endif

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/ISnapshotSelector.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/ISnapshotSelector.cs
@@ -1,0 +1,36 @@
+﻿// <copyright file="ISnapshotSelector.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET
+
+using System.Diagnostics;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Snapshots
+{
+    /// <summary>
+    /// Represents snapshot selector.
+    /// </summary>
+    internal interface ISnapshotSelector
+    {
+        /// <summary>
+        /// Method for selecting trace for capturing snapshots.
+        /// </summary>
+        /// <param name="context">Current span context.</param>
+        /// <returns>Returns <c>true</c> if snapshots should be captured for the trace; otherwise, <c>false</c>.</returns>
+        public bool Select(ActivityContext context);
+    }
+}
+#endif

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/NativeMethods.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/NativeMethods.cs
@@ -1,0 +1,56 @@
+﻿// <copyright file="NativeMethods.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET
+
+using System.Diagnostics;
+using System.Reflection;
+using Splunk.OpenTelemetry.AutoInstrumentation.Logging;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Snapshots
+{
+    internal static class NativeMethods
+    {
+        private static readonly ILogger Log = new Logger();
+
+        static NativeMethods()
+        {
+            try
+            {
+                var nativeMethodsType = Type.GetType("OpenTelemetry.AutoInstrumentation.NativeMethods, OpenTelemetry.AutoInstrumentation");
+                if (nativeMethodsType == null)
+                {
+                    throw new Exception("OpenTelemetry.AutoInstrumentation.NativeMethods could not be found.");
+                }
+
+                var startMethod = nativeMethodsType.GetMethod("SelectiveSamplingStart", BindingFlags.Static | BindingFlags.Public, null, [typeof(Activity)], null);
+                var stopMethod = nativeMethodsType!.GetMethod("SelectiveSamplingStop", BindingFlags.Static | BindingFlags.Public, null, [typeof(Activity)], null);
+
+                StartSamplingDelegate = (Action<Activity>)Delegate.CreateDelegate(typeof(Action<Activity>), startMethod!);
+                StopSamplingDelegate = (Action<Activity>)Delegate.CreateDelegate(typeof(Action<Activity>), stopMethod!);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to initialize sampling methods");
+            }
+        }
+
+        public static Action<Activity>? StopSamplingDelegate { get; }
+
+        public static Action<Activity>? StartSamplingDelegate { get; }
+    }
+}
+#endif

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/ProbabilisticVolumeSelector.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/ProbabilisticVolumeSelector.cs
@@ -1,0 +1,48 @@
+﻿// <copyright file="ProbabilisticVolumeSelector.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET
+
+using System.Diagnostics;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Snapshots
+{
+    internal class ProbabilisticVolumeSelector : ISnapshotSelector
+    {
+        private readonly double _ratio;
+
+        public ProbabilisticVolumeSelector(double ratio)
+        {
+            _ratio = ratio;
+        }
+
+        public bool Select(ActivityContext context)
+        {
+            if (!IndicatesRootSpan(context))
+            {
+                return false;
+            }
+
+            return Random.Shared.NextDouble() <= _ratio;
+        }
+
+        private static bool IndicatesRootSpan(ActivityContext context)
+        {
+            return context == default;
+        }
+    }
+}
+#endif

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/SnapshotActivityExtensions.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/SnapshotActivityExtensions.cs
@@ -1,0 +1,36 @@
+﻿// <copyright file="SnapshotActivityExtensions.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET
+
+using System.Diagnostics;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Snapshots
+{
+    internal static class SnapshotActivityExtensions
+    {
+        public static void MarkLoud(this Activity activity)
+        {
+            activity.SetTag(SnapshotConstants.SplunkSnapshotProfilingAttributeName, true);
+        }
+
+        public static bool IsEntry(this Activity activity)
+        {
+            return activity.Parent is null || activity.HasRemoteParent;
+        }
+    }
+}
+#endif

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/SnapshotConstants.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/SnapshotConstants.cs
@@ -1,0 +1,27 @@
+﻿// <copyright file="SnapshotConstants.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Snapshots
+{
+    internal static class SnapshotConstants
+    {
+        public const string VolumeBaggageKeyName = "splunk.trace.snapshot.volume";
+        public const string SplunkSnapshotProfilingAttributeName = "splunk.snapshot.profiling";
+    }
+}
+#endif

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/SnapshotFilter.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/SnapshotFilter.cs
@@ -1,0 +1,49 @@
+﻿// <copyright file="SnapshotFilter.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Diagnostics;
+
+#if NET
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Snapshots
+{
+    internal class SnapshotFilter
+    {
+        private static readonly Lazy<SnapshotFilter> InstanceFactory = new(() => new SnapshotFilter(NativeMethods.StartSamplingDelegate, NativeMethods.StopSamplingDelegate));
+
+        private readonly Action<Activity>? _startSamplingDelegate;
+        private readonly Action<Activity>? _stopSamplingDelegate;
+
+        internal SnapshotFilter(Action<Activity>? startSamplingDelegate, Action<Activity>? stopSamplingDelegate)
+        {
+            _startSamplingDelegate = startSamplingDelegate;
+            _stopSamplingDelegate = stopSamplingDelegate;
+        }
+
+        public static SnapshotFilter Instance => InstanceFactory.Value;
+
+        public void Add(Activity data)
+        {
+            _startSamplingDelegate?.Invoke(data);
+        }
+
+        public void Remove(Activity data)
+        {
+            _stopSamplingDelegate?.Invoke(data);
+        }
+    }
+}
+#endif

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/SnapshotSelectingProcessor.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/SnapshotSelectingProcessor.cs
@@ -1,0 +1,63 @@
+﻿// <copyright file="SnapshotSelectingProcessor.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET
+
+using System.Diagnostics;
+using OpenTelemetry;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Snapshots
+{
+    internal class SnapshotSelectingProcessor : BaseProcessor<Activity>
+    {
+        private readonly SnapshotFilter _snapshotFilter;
+
+        public SnapshotSelectingProcessor()
+            : this(SnapshotFilter.Instance)
+        {
+        }
+
+        public SnapshotSelectingProcessor(SnapshotFilter snapshotFilter)
+        {
+            _snapshotFilter = snapshotFilter;
+        }
+
+        public override void OnStart(Activity data)
+        {
+            if (SnapshotVolumeDetector.IsLoud(Baggage.Current))
+            {
+                if (data.IsEntry())
+                {
+                    data.MarkLoud();
+                }
+
+                _snapshotFilter.Add(data);
+            }
+        }
+
+        public override void OnEnd(Activity data)
+        {
+            // Instead of relying on entry being present in Baggage.Current,
+            // we could track entries added in OnStart in a ConcurrentDictionary.
+            // This would help if baggage was to change between OnStart and OnEnd.
+            if (SnapshotVolumeDetector.IsLoud(Baggage.Current))
+            {
+                _snapshotFilter.Remove(data);
+            }
+        }
+    }
+}
+#endif

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/SnapshotVolumeDetector.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/SnapshotVolumeDetector.cs
@@ -1,0 +1,33 @@
+﻿// <copyright file="SnapshotVolumeDetector.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET
+
+using OpenTelemetry;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Snapshots
+{
+    internal static class SnapshotVolumeDetector
+    {
+        public static bool IsLoud(Baggage baggage)
+        {
+            var volume = baggage.GetBaggage(SnapshotConstants.VolumeBaggageKeyName);
+
+            return volume != null && volume.Equals("highest", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}
+#endif

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/SnapshotVolumePropagator.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/SnapshotVolumePropagator.cs
@@ -1,0 +1,66 @@
+﻿// <copyright file="SnapshotVolumePropagator.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET
+
+using OpenTelemetry;
+using OpenTelemetry.Context.Propagation;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Snapshots
+{
+    internal class SnapshotVolumePropagator : TextMapPropagator
+    {
+        private readonly ISnapshotSelector _selector;
+
+        public SnapshotVolumePropagator(ISnapshotSelector selector)
+        {
+            _selector = selector;
+        }
+
+        public override ISet<string>? Fields { get; } = new HashSet<string>();
+
+        public override void Inject<T>(PropagationContext context, T carrier, Action<T, string, string> setter)
+        {
+        }
+
+        public override PropagationContext Extract<T>(PropagationContext context, T carrier, Func<T, string, IEnumerable<string>?> getter)
+        {
+            var baggage = context.Baggage;
+            var volume = baggage.GetBaggage(SnapshotConstants.VolumeBaggageKeyName);
+            if (volume != null)
+            {
+                return context;
+            }
+
+            var newVolume = _selector.Select(context.ActivityContext) ? Volume.highest : Volume.off;
+
+            var updatedBaggage = context.Baggage.SetBaggage(SnapshotConstants.VolumeBaggageKeyName, GetStringValue(newVolume));
+            return new PropagationContext(context.ActivityContext, updatedBaggage);
+        }
+
+        private static string GetStringValue(Volume newVolume)
+        {
+            return newVolume switch
+            {
+                Volume.highest => nameof(Volume.highest),
+                Volume.off => nameof(Volume.off),
+                Volume.unspecified => nameof(Volume.unspecified),
+                _ => newVolume.ToString()
+            };
+        }
+    }
+}
+#endif

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/TraceIdBasedSnapshotSelector.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/TraceIdBasedSnapshotSelector.cs
@@ -1,0 +1,47 @@
+﻿// <copyright file="TraceIdBasedSnapshotSelector.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET
+
+using System.Diagnostics;
+using OpenTelemetry.Trace;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Snapshots
+{
+    internal class TraceIdBasedSnapshotSelector : ISnapshotSelector
+    {
+        private readonly TraceIdRatioBasedSampler _sampler;
+
+        public TraceIdBasedSnapshotSelector(double ratio)
+        {
+            _sampler = new TraceIdRatioBasedSampler(ratio);
+        }
+
+        public bool Select(ActivityContext context)
+        {
+            // context.IsValid() checks if context != default
+            if (context.TraceId == default)
+            {
+                return false;
+            }
+
+            // Only TraceId is used from sampling parameters
+            var samplingParameters = new SamplingParameters(default, context.TraceId, string.Empty, ActivityKind.Internal);
+            return _sampler.ShouldSample(samplingParameters).Decision == SamplingDecision.RecordAndSample;
+        }
+    }
+}
+#endif

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/Volume.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/Volume.cs
@@ -1,0 +1,31 @@
+﻿// <copyright file="Volume.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET
+
+// ReSharper disable InconsistentNaming
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Snapshots
+{
+    internal enum Volume
+    {
+#pragma warning disable SA1300
+        unspecified,
+        off,
+        highest
+#pragma warning restore SA1300
+    }
+}
+#endif

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Splunk.OpenTelemetry.AutoInstrumentation.csproj
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Splunk.OpenTelemetry.AutoInstrumentation.csproj
@@ -73,5 +73,8 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Splunk.OpenTelemetry.AutoInstrumentation.Tests</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 </Project>

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/PluginTests.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/PluginTests.cs
@@ -1,0 +1,105 @@
+﻿// <copyright file="PluginTests.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET
+
+using System.Collections.Specialized;
+using System.Runtime.CompilerServices;
+using OpenTelemetry.Context.Propagation;
+using OpenTelemetry.Trace;
+using Splunk.OpenTelemetry.AutoInstrumentation.Configuration;
+using Splunk.OpenTelemetry.AutoInstrumentation.Pprof.Proto.Profile;
+using Splunk.OpenTelemetry.AutoInstrumentation.Snapshots;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Tests
+{
+    public class PluginTests
+    {
+        [Fact]
+        public void WhenSnapshotsAreEnabledAndBaggagePropagatorIsNotConfigured_ExceptionIsThrown()
+        {
+            // Force SDK init.
+            _ = global::OpenTelemetry.Sdk.SuppressInstrumentation;
+
+            var defaultPropagator = global::OpenTelemetry.Context.Propagation.Propagators.DefaultTextMapPropagator;
+
+            // Replace default propagator which propagates baggage with something else.
+            global::OpenTelemetry.Sdk.SetDefaultTextMapPropagator(new TraceContextPropagator());
+
+            var defaultFactory = Plugin.DefaultSettingsFactory;
+
+            try
+            {
+                Plugin.DefaultSettingsFactory = () => new PluginSettings(new NameValueConfigurationSource(
+                    new NameValueCollection
+                    {
+                        ["SPLUNK_SNAPSHOT_PROFILER_ENABLED"] = "true"
+                    }));
+
+                var plugin = new Plugin();
+                var builder = new TracerProviderBuilderBase();
+                Assert.Throws<NotSupportedException>(() => plugin.BeforeConfigureTracerProvider(builder));
+            }
+            finally
+            {
+                global::OpenTelemetry.Sdk.SetDefaultTextMapPropagator(defaultPropagator);
+                Plugin.DefaultSettingsFactory = defaultFactory;
+            }
+        }
+
+        [Fact]
+        public void WhenSnapshotsAreEnabledAndBaggagePropagatorIsConfigured_SdkIsCustomized()
+        {
+            // Force SDK init.
+            _ = global::OpenTelemetry.Sdk.SuppressInstrumentation;
+
+            var defaultPropagator = global::OpenTelemetry.Context.Propagation.Propagators.DefaultTextMapPropagator;
+
+            var defaultFactory = Plugin.DefaultSettingsFactory;
+
+            try
+            {
+                Plugin.DefaultSettingsFactory = () => new PluginSettings(new NameValueConfigurationSource(
+                    new NameValueCollection
+                    {
+                        ["SPLUNK_SNAPSHOT_PROFILER_ENABLED"] = "true"
+                    }));
+
+                var plugin = new Plugin();
+                var builder = new TracerProviderBuilderBase();
+
+                plugin.BeforeConfigureTracerProvider(builder);
+
+                var configuredPropagator = Propagators.DefaultTextMapPropagator;
+                var propagators = GetPropagators((CompositeTextMapPropagator)configuredPropagator);
+
+                Assert.Equal(2, propagators.Count);
+
+                Assert.Equal(propagators[0], defaultPropagator);
+                Assert.IsType<SnapshotVolumePropagator>(propagators[1]);
+            }
+            finally
+            {
+                global::OpenTelemetry.Sdk.SetDefaultTextMapPropagator(defaultPropagator);
+                Plugin.DefaultSettingsFactory = defaultFactory;
+            }
+        }
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "propagators")]
+        private static extern ref List<TextMapPropagator> GetPropagators(CompositeTextMapPropagator @this);
+    }
+}
+#endif

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/PprofInOtlpLogsExporterTests.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/PprofInOtlpLogsExporterTests.cs
@@ -1,0 +1,70 @@
+﻿// <copyright file="PprofInOtlpLogsExporterTests.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+#if NET
+
+using Splunk.OpenTelemetry.AutoInstrumentation.ContinuousProfiler;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Tests
+{
+    public class PprofInOtlpLogsExporterTests
+    {
+        [Fact]
+        public void WhenThreadIsSelectedForFrequentSampling_ItsSampleIsExportedAsBothContinuousAndSnapshot()
+        {
+            var testExporter = new TestSampleExporter();
+            List<ThreadSample>? threadSamples = [
+                new ThreadSample(new ThreadSample.Time(100), 1, 1, 1, "sample_thread_1", 0, false) { Frames = { "frame1", "frame2" } },
+                new ThreadSample(new ThreadSample.Time(100), 2, 2, 2, "sample_thread_2", 1, true) { Frames = { "frame3" } }
+            ];
+            var exporter = new PprofInOtlpLogsExporter(new SampleProcessor(), testExporter, new NativeFormatParser(true));
+
+            exporter.ExportThreadSamplesCore(threadSamples, CancellationToken.None);
+
+            var exportedRecords = testExporter.Records;
+            Assert.Equal(2, exportedRecords.Count);
+
+            var sampleForThreadNotSelectedForSnapshots = exportedRecords[0];
+
+            // For continuous profiling samples, `profiling.instrumentation.source` attribute can be omitted.
+            Assert.DoesNotContain(sampleForThreadNotSelectedForSnapshots.Attributes, kv => kv.Key == "profiling.instrumentation.source");
+            Assert.Contains(sampleForThreadNotSelectedForSnapshots.Attributes, kv => kv.Key == "profiling.data.total.frame.count" && kv.Value.IntValue == 3);
+
+            // For snapshot samples, `profiling.instrumentation.source` attribute is required to have value of `snapshot`.
+            var threadSampleForThreadSelectedForSnapshots = exportedRecords[1];
+            Assert.Contains(threadSampleForThreadSelectedForSnapshots.Attributes, kv => kv.Key == "profiling.instrumentation.source" && kv.Value.StringValue == "snapshot");
+            Assert.Contains(threadSampleForThreadSelectedForSnapshots.Attributes, kv => kv.Key == "profiling.data.total.frame.count" && kv.Value.IntValue == 1);
+        }
+
+        [Fact]
+        public void WhenThreadIsNotSelectedForFrequentSampling_ItsSampleIsExportedAsContinuous()
+        {
+            var testExporter = new TestSampleExporter();
+            List<ThreadSample>? threadSamples = [
+                new ThreadSample(new ThreadSample.Time(100), 1, 1, 1, "sample_thread_1", 0, false),
+                new ThreadSample(new ThreadSample.Time(100), 2, 2, 2, "sample_thread_2", 1, false)
+            ];
+            var exporter = new PprofInOtlpLogsExporter(new SampleProcessor(), testExporter, new NativeFormatParser(true));
+            exporter.ExportThreadSamplesCore(threadSamples, CancellationToken.None);
+
+            var exportedRecords = testExporter.Records;
+            Assert.Single(exportedRecords);
+
+            // For continuous profiling samples, `profiling.instrumentation.source` attribute can be omitted.
+            Assert.All(exportedRecords, lr => Assert.DoesNotContain(lr.Attributes, kv => kv.Key == "profiling.instrumentation.source"));
+        }
+    }
+}
+#endif

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/SettingsTests.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/SettingsTests.cs
@@ -14,6 +14,9 @@
 // limitations under the License.
 // </copyright>
 
+using System.Collections.Specialized;
+using Splunk.OpenTelemetry.AutoInstrumentation.Configuration;
+
 namespace Splunk.OpenTelemetry.AutoInstrumentation.Tests
 {
     public class SettingsTests : IDisposable
@@ -27,6 +30,19 @@ namespace Splunk.OpenTelemetry.AutoInstrumentation.Tests
         {
             ClearEnvVars();
         }
+
+#if NET
+        [Fact]
+        public void MaxSnapshotSelectionRate_IsBoundedByTheValueFromTheSpec()
+        {
+            var settings = new PluginSettings(new NameValueConfigurationSource(
+                new NameValueCollection
+                {
+                    ["SPLUNK_SNAPSHOT_SELECTION_RATE"] = "0.5"
+                }));
+            Assert.Equal(0.1, settings.SnapshotsSelectionRate);
+        }
+#endif
 
         [Fact]
         internal void PluginSettings_DefaultValues()
@@ -60,6 +76,9 @@ namespace Splunk.OpenTelemetry.AutoInstrumentation.Tests
             Environment.SetEnvironmentVariable(ConfigurationKeys.Splunk.AlwaysOnProfiler.ProfilerExportTimeout, null);
             Environment.SetEnvironmentVariable(ConfigurationKeys.Splunk.AlwaysOnProfiler.ProfilerExportInterval, null);
             Environment.SetEnvironmentVariable(ConfigurationKeys.Splunk.AlwaysOnProfiler.ProfilerMaxMemorySamples, null);
+            Environment.SetEnvironmentVariable(ConfigurationKeys.Splunk.Snapshots.Enabled, null);
+            Environment.SetEnvironmentVariable(ConfigurationKeys.Splunk.Snapshots.SamplingIntervalMs, null);
+            Environment.SetEnvironmentVariable(ConfigurationKeys.Splunk.Snapshots.SelectionRate, null);
 #endif
         }
     }

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/Snapshots/ProbabilisticVolumeSelectorTests.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/Snapshots/ProbabilisticVolumeSelectorTests.cs
@@ -1,0 +1,37 @@
+﻿// <copyright file="ProbabilisticVolumeSelectorTests.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET
+using System.Diagnostics;
+using Splunk.OpenTelemetry.AutoInstrumentation.Snapshots;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Tests.Snapshots
+{
+    public class ProbabilisticVolumeSelectorTests
+    {
+        [Fact]
+        public void Select_ShouldReturnFalse_ForNonRootSpan()
+        {
+            var selector = new ProbabilisticVolumeSelector(1.0);
+            var context = new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.None);
+
+            var result = selector.Select(context);
+
+            Assert.False(result);
+        }
+    }
+}
+#endif

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/Snapshots/SnapshotVolumeDetectorTests.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/Snapshots/SnapshotVolumeDetectorTests.cs
@@ -1,0 +1,51 @@
+﻿// <copyright file="SnapshotVolumeDetectorTests.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET
+
+using OpenTelemetry;
+using Splunk.OpenTelemetry.AutoInstrumentation.Snapshots;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Tests.Snapshots
+{
+    public class SnapshotVolumeDetectorTests
+    {
+        [Fact]
+        public void IfBaggageContainsVolumeKeyWithHighestValue_IsConsideredLoud()
+        {
+            var testBaggage = Baggage.Create(new Dictionary<string, string> { ["splunk.trace.snapshot.volume"] = "highest" });
+            var startSamplingDecision = SnapshotVolumeDetector.IsLoud(testBaggage);
+            Assert.True(startSamplingDecision);
+        }
+
+        [Fact]
+        public void IfBaggageContainsVolumeKeyWithOffValue_IsNotConsideredLoud()
+        {
+            var testBaggage = Baggage.Create(new Dictionary<string, string> { ["splunk.trace.snapshot.volume"] = "off" });
+            var startSamplingDecision = SnapshotVolumeDetector.IsLoud(testBaggage);
+            Assert.False(startSamplingDecision);
+        }
+
+        [Fact]
+        public void IfBaggageContainsNoVolumeKey_IsNotConsideredLoud()
+        {
+            var testBaggage = Baggage.Create(new Dictionary<string, string>());
+            var startSamplingDecision = SnapshotVolumeDetector.IsLoud(testBaggage);
+            Assert.False(startSamplingDecision);
+        }
+    }
+}
+#endif

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/Snapshots/SnapshotVolumePropagatorTests.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/Snapshots/SnapshotVolumePropagatorTests.cs
@@ -1,0 +1,81 @@
+﻿// <copyright file="SnapshotVolumePropagatorTests.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET
+
+using System.Diagnostics;
+using OpenTelemetry;
+using OpenTelemetry.Context.Propagation;
+using Splunk.OpenTelemetry.AutoInstrumentation.Snapshots;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Tests.Snapshots
+{
+    public class SnapshotVolumePropagatorTests
+    {
+        [Fact]
+        public void IfVolumeWasDecided_FollowTheDecision()
+        {
+            var selectNeverSelector = new CompositeSelector(0.0);
+            var propagator = new SnapshotVolumePropagator(selectNeverSelector);
+
+            var dict = new Dictionary<string, object>();
+
+            var extractedContext = propagator.Extract(
+                new PropagationContext(default, Baggage.Create(new Dictionary<string, string> { ["splunk.trace.snapshot.volume"] = "highest" })),
+                dict,
+                (_, _) => throw new InvalidOperationException());
+
+            Assert.Equal("highest", extractedContext.Baggage.GetBaggage("splunk.trace.snapshot.volume"));
+        }
+
+        [Theory]
+        [InlineData(1.0, "highest")]
+        [InlineData(0.0, "off")]
+        public void IfVolumeWasNotDecided_MakeADecisionForRootSpans(double ratio, string expectedValue)
+        {
+            var propagator = new SnapshotVolumePropagator(new CompositeSelector(ratio));
+
+            var dict = new Dictionary<string, object>();
+
+            var rootSpanIndicatingContext = default(ActivityContext);
+            var extractedContext = propagator.Extract(
+                new PropagationContext(rootSpanIndicatingContext, default),
+                dict,
+                (_, _) => throw new InvalidOperationException());
+
+            Assert.Equal(expectedValue, extractedContext.Baggage.GetBaggage("splunk.trace.snapshot.volume"));
+        }
+
+        [Theory]
+        [InlineData(1.0, "highest")]
+        [InlineData(0.0, "off")]
+        public void IfVolumeWasNotDecided_MakeADecisionForNonRootSpans(double ratio, string expectedValue)
+        {
+            var propagator = new SnapshotVolumePropagator(new CompositeSelector(ratio));
+
+            var dict = new Dictionary<string, object>();
+
+            var nonRootSpanContext = new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded);
+            var extractedContext = propagator.Extract(
+                new PropagationContext(nonRootSpanContext, default),
+                dict,
+                (_, _) => throw new InvalidOperationException());
+
+            Assert.Equal(expectedValue, extractedContext.Baggage.GetBaggage("splunk.trace.snapshot.volume"));
+        }
+    }
+}
+#endif

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/Snapshots/TraceIdBasedVolumeSelectorTests.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/Snapshots/TraceIdBasedVolumeSelectorTests.cs
@@ -1,0 +1,35 @@
+﻿// <copyright file="TraceIdBasedVolumeSelectorTests.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+#if NET
+using Splunk.OpenTelemetry.AutoInstrumentation.Snapshots;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Tests.Snapshots
+{
+    public class TraceIdBasedVolumeSelectorTests
+    {
+        [Fact]
+        public void Select_ShouldReturnFalse_ForDefaultContext()
+        {
+            var selector = new TraceIdBasedSnapshotSelector(1.0);
+            var context = default(System.Diagnostics.ActivityContext);
+
+            var result = selector.Select(context);
+
+            Assert.False(result);
+        }
+    }
+}
+#endif

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/TestSampleExporter.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/TestSampleExporter.cs
@@ -1,0 +1,33 @@
+﻿// <copyright file="TestSampleExporter.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET
+using Splunk.OpenTelemetry.AutoInstrumentation.ContinuousProfiler;
+using Splunk.OpenTelemetry.AutoInstrumentation.Proto.Logs.V1;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Tests
+{
+    internal class TestSampleExporter : ISampleExporter
+    {
+        public List<LogRecord> Records { get; } = new List<LogRecord>();
+
+        public void Export(LogRecord logRecord, CancellationToken cancellationToken)
+        {
+            Records.Add(logRecord);
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Supersedes: #642 

Initial implementation of snapshots collection for .NET.
Follows similar approach to https://github.com/signalfx/splunk-otel-java/tree/main/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot.

At trace root, traces are selected for snapshotting based on configured percentage.

Decision regarding volume is stored and propagated using baggage.

Plugin API is used to customize the TracerProvider created by the autoinstrumentation.

Main components:
- `SnapshotSelectingProcessor`: selects spans for spanshot collection
- `SnapshotVolumePropagator`: decides on volume and stores decision in baggage if baggage contains no volume
- `ProbabilisticVolumeSelector`: selects spans for snapshots at random for root spans
- `TraceIdBasedSnapshotSelector`: selects spans for snapshots based on traceId for non-root spans