### PR TITLE
FOSSA scans - trigger fix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,6 +22,7 @@ oss-scan:
   stage: fossa-scan
   rules:
     - if: '$CI_COMMIT_REF_NAME == "main"'
+      when: always
   extends: .oss-scan
   dependencies:
     - build


### PR DESCRIPTION
From 

Clauud Sonet 4.5
However, this rule is not allowing the job to run on pushes to the main branch by default. In GitLab CI, when you use rules:, you need to be explicit about when the job should run. The current configuration only checks if the branch name is "main" but doesn't specify the trigger conditions properly.

The fix is to add when: always or ensure the rule is properly structured for push events. Here's the corrected configuration: