### PR TITLE
[tests] use simple exporter in logs resource tests

### DIFF
--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/SmokeTests.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/SmokeTests.cs
@@ -45,6 +45,8 @@ public class SmokeTests : TestHelper, IDisposable
     {
         SetEnvironmentVariable("OTEL_SERVICE_NAME", ServiceName);
         SetEnvironmentVariable("OTEL_DOTNET_AUTO_TRACES_ENABLED_INSTRUMENTATIONS", "HttpClient");
+        SetEnvironmentVariable("OTEL_EXPERIMENTAL_FILE_BASED_CONFIGURATION_ENABLED", "false");
+
         _testServer = TestHttpServer.CreateDefaultTestServer(output);
     }
 
@@ -152,12 +154,12 @@ public class SmokeTests : TestHelper, IDisposable
     public void LogsResource()
     {
         using var collector = new MockLogsCollector(Output);
-        SetExporter(collector);
+        EnableFileBasedConfig("log-exporter-config.yaml");
+        SetFileBasedExporter(collector);
 
         collector.ResourceExpector.ExpectDistributionResources(ServiceName);
 
         EnableBytecodeInstrumentation();
-        SetEnvironmentVariable("OTEL_BLRP_MAX_EXPORT_BATCH_SIZE", "1");
 
         RunTestApplication(TestSettingsWithDefaultArgs());
 

--- a/test/test-applications/integrations/TestApplication.Smoke/TestApplication.Smoke.csproj
+++ b/test/test-applications/integrations/TestApplication.Smoke/TestApplication.Smoke.csproj
@@ -14,4 +14,9 @@
   <ItemGroup>
     <ProjectReference Include="..\dependency-libs\TestApplication.Shared\TestApplication.Shared.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <None Update="log-exporter-config.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/test/test-applications/integrations/TestApplication.Smoke/log-exporter-config.yaml
+++ b/test/test-applications/integrations/TestApplication.Smoke/log-exporter-config.yaml
@@ -1,0 +1,17 @@
+file_format: "1.0-rc.1"
+
+instrumentation/development:
+  dotnet:
+    logs:
+      ilogger:
+
+plugins/development:
+  plugins:
+    - Splunk.OpenTelemetry.AutoInstrumentation.Plugin, Splunk.OpenTelemetry.AutoInstrumentation
+
+logger_provider:
+  processors:
+    - simple:
+        exporter:
+          otlp_http:
+            endpoint: ${OTEL_EXPORTER_OTLP_LOGS_ENDPOINT}


### PR DESCRIPTION
Use simple exporter in attempt to reduce flakiness.
Setting exporter to simple for logs is problematic with env variables-based configuration, so I switched to file-based config for this specific test.