### PR TITLE
Add an entry to the file-based docs about plugins

### DIFF
--- a/docs/file-based-configuration.md
+++ b/docs/file-based-configuration.md
@@ -2,7 +2,7 @@
 
 You can configure Splunk Distribution of OpenTelemetry .NET using a YAML file.
 
-> ⚠️ **Important:**
+> [!IMPORTANT]
 > To start using the Splunk Distribution of OpenTelemetry .NET with file-based configuration,
 > you **must** configure the plugin in a YAML file.
 


### PR DESCRIPTION
## Why & What

Add an entry to the file-based configuration docs clarifying that, to use the Splunk Distribution of OpenTelemetry .NET with file-based configuration, the plugin must be configured in a YAML file.

