### PR TITLE
CallGraphs not getting associated with traces for .Net Framework

### DIFF
--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/SnapshotActivityExtensions.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/SnapshotActivityExtensions.cs
@@ -22,7 +22,7 @@ internal static class SnapshotActivityExtensions
 {
     public static void MarkLoud(this Activity activity)
     {
-        activity.SetTag(SnapshotConstants.SplunkSnapshotProfilingAttributeName, true);
+        activity.SetTag(SnapshotConstants.SplunkSnapshotProfilingAttributeName, "true");
     }
 
     public static bool IsLocalRoot(this Activity activity)

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/SnapshotSelectingProcessor.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Snapshots/SnapshotSelectingProcessor.cs
@@ -31,6 +31,7 @@ internal class SnapshotSelectingProcessor : BaseProcessor<Activity>
     private readonly SnapshotFilter _snapshotFilter;
     private readonly ISnapshotSelector _snapshotSelector;
     private readonly ConcurrentDictionary<(ActivitySpanId, ActivityTraceId), DateTimeOffset> _localRootSpans = new();
+    private readonly ConcurrentDictionary<ActivityTraceId, byte> _selectedTraceIds = new();
     private readonly Timer _timer;
 
     public SnapshotSelectingProcessor(SnapshotFilter snapshotFilter, ISnapshotSelector snapshotSelector)
@@ -44,11 +45,20 @@ internal class SnapshotSelectingProcessor : BaseProcessor<Activity>
     {
         if (!data.IsLocalRoot())
         {
+            // Propagate the snapshot tag to child activities whose trace
+            // was already selected for snapshotting by the local root.
+            if (_selectedTraceIds.ContainsKey(data.TraceId))
+            {
+                Log.Debug($"Propagating snapshot tag to child {data.DisplayName} (SpanId={data.SpanId}) on trace {data.TraceId}.");
+                data.MarkLoud();
+            }
+
             return;
         }
 
         if (!_snapshotSelector.Select(data.Context))
         {
+            Log.Debug($"Trace {data.TraceId} not selected by snapshot selector.");
             return;
         }
 
@@ -60,6 +70,7 @@ internal class SnapshotSelectingProcessor : BaseProcessor<Activity>
 
         data.MarkLoud();
         _snapshotFilter.Add(data.TraceId);
+        _selectedTraceIds.TryAdd(data.TraceId, 0);
         var cacheKey = (data.SpanId, data.TraceId);
         if (!_localRootSpans.TryAdd(cacheKey, DateTimeOffset.UtcNow + DefaultTimeToLive))
         {
@@ -73,6 +84,7 @@ internal class SnapshotSelectingProcessor : BaseProcessor<Activity>
         if (_localRootSpans.TryRemove(cacheKey, out _))
         {
             _snapshotFilter.Remove(data.TraceId);
+            _selectedTraceIds.TryRemove(data.TraceId, out _);
         }
     }
 
@@ -96,6 +108,7 @@ internal class SnapshotSelectingProcessor : BaseProcessor<Activity>
             {
                 _localRootSpans.TryRemove(kvp.Key, out _);
                 _snapshotFilter.Remove(kvp.Key.Item2);
+                _selectedTraceIds.TryRemove(kvp.Key.Item2, out _);
             }
         }
     }

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/SnapshotSelectingProcessorTests.cs
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.Tests/SnapshotSelectingProcessorTests.cs
@@ -1,0 +1,137 @@
+// <copyright file="SnapshotSelectingProcessorTests.cs" company="Splunk Inc.">
+// Copyright Splunk Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Diagnostics;
+using Splunk.OpenTelemetry.AutoInstrumentation.Snapshots;
+
+namespace Splunk.OpenTelemetry.AutoInstrumentation.Tests;
+
+public class SnapshotSelectingProcessorTests : IDisposable
+{
+    private readonly ActivitySource _source = new("Test.Snapshots");
+    private readonly ActivityListener _listener;
+
+    public SnapshotSelectingProcessorTests()
+    {
+        Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+        Activity.ForceDefaultIdFormat = true;
+
+        _listener = new ActivityListener
+        {
+            ShouldListenTo = _ => true,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded
+        };
+        ActivitySource.AddActivityListener(_listener);
+    }
+
+    [Fact]
+    public void LocalRoot_SelectedTrace_IsMarkedLoud()
+    {
+        var filter = new SnapshotFilter(null, null);
+        var processor = new SnapshotSelectingProcessor(filter, new AlwaysSelectSelector());
+
+        using var root = _source.StartActivity("root");
+        Assert.NotNull(root);
+
+        processor.OnStart(root);
+
+        Assert.Equal("true", root.GetTagItem(SnapshotConstants.SplunkSnapshotProfilingAttributeName));
+    }
+
+    [Fact]
+    public void LocalRoot_NotSelectedTrace_IsNotMarkedLoud()
+    {
+        var filter = new SnapshotFilter(null, null);
+        var processor = new SnapshotSelectingProcessor(filter, new NeverSelectSelector());
+
+        using var root = _source.StartActivity("root");
+        Assert.NotNull(root);
+
+        processor.OnStart(root);
+
+        Assert.Null(root.GetTagItem(SnapshotConstants.SplunkSnapshotProfilingAttributeName));
+    }
+
+    [Fact]
+    public void ChildSpan_PropagatesTag_WhenTraceIsSelected()
+    {
+        var filter = new SnapshotFilter(null, null);
+        var processor = new SnapshotSelectingProcessor(filter, new AlwaysSelectSelector());
+
+        using var root = _source.StartActivity("root");
+        Assert.NotNull(root);
+        processor.OnStart(root);
+
+        using var child = _source.StartActivity("child");
+        Assert.NotNull(child);
+        Assert.NotNull(child.Parent);
+        Assert.Null(child.GetTagItem(SnapshotConstants.SplunkSnapshotProfilingAttributeName));
+        processor.OnStart(child);
+
+        Assert.Equal("true", child.GetTagItem(SnapshotConstants.SplunkSnapshotProfilingAttributeName));
+    }
+
+    [Fact]
+    public void ChildSpan_DoesNotGetTag_WhenTraceIsNotSelected()
+    {
+        var filter = new SnapshotFilter(null, null);
+        var processor = new SnapshotSelectingProcessor(filter, new NeverSelectSelector());
+
+        using var root = _source.StartActivity("root");
+        Assert.NotNull(root);
+        processor.OnStart(root);
+
+        using var child = _source.StartActivity("child");
+        Assert.NotNull(child);
+        processor.OnStart(child);
+
+        Assert.Null(child.GetTagItem(SnapshotConstants.SplunkSnapshotProfilingAttributeName));
+    }
+
+    [Fact]
+    public void ChildSpan_DoesNotGetTag_AfterLocalRootEnds()
+    {
+        var filter = new SnapshotFilter(null, null);
+        var processor = new SnapshotSelectingProcessor(filter, new AlwaysSelectSelector());
+
+        using var root = _source.StartActivity("root");
+        Assert.NotNull(root);
+        processor.OnStart(root);
+        processor.OnEnd(root);
+
+        using var lateChild = _source.StartActivity("late-child");
+        Assert.NotNull(lateChild);
+        processor.OnStart(lateChild);
+
+        Assert.Null(lateChild.GetTagItem(SnapshotConstants.SplunkSnapshotProfilingAttributeName));
+    }
+
+    public void Dispose()
+    {
+        _listener.Dispose();
+        _source.Dispose();
+    }
+
+    private class AlwaysSelectSelector : ISnapshotSelector
+    {
+        public bool Select(ActivityContext context) => true;
+    }
+
+    private class NeverSelectSelector : ISnapshotSelector
+    {
+        public bool Select(ActivityContext context) => false;
+    }
+}


### PR DESCRIPTION
Propagate Profiling tag to child spans
Problem
The Profiling tag was only set on the local root activity. Child spans never received it because OnStart(Activity) returned early for all non-root spans. On .NET 8 this was masked because the exported span is the local root. On .NET Framework, child spans are the ones exported — so the tag was missing.
Changes
•	SnapshotSelectingProcessor.cs — Added _selectedTraceIds dictionary to track selected traces. Non-root spans now check this dictionary and inherit the tag via MarkLoud().
•	SnapshotActivityExtensions.cs — Changed tag value from bool to string for .NET Framework Tags compatibility.
•	SnapshotSelectingProcessorTests.cs (new) — Unit tests for root tagging, child propagation, and cleanup.
