### PR TITLE
[tests] workaround yaml config log exporter issue

### DIFF
--- a/test/test-applications/integrations/TestApplication.Smoke/log-exporter-config.yaml
+++ b/test/test-applications/integrations/TestApplication.Smoke/log-exporter-config.yaml
@@ -11,7 +11,8 @@ plugins/development:
 
 logger_provider:
   processors:
-    - simple:
+    - batch:
+        max_export_batch_size: 1
         exporter:
           otlp_http:
             endpoint: ${OTEL_EXPORTER_OTLP_LOGS_ENDPOINT}


### PR DESCRIPTION
Attempt to configure simple exporter in logger provider section of yaml file results in batch exporter being used. In order to try to reduce the flakiness, limit batch size of batch exporter to 1.