### PR TITLE
[docs] Clarify that memory profiling is not supported on the .NET Framework

### DIFF
--- a/docs/file-based-configuration.md
+++ b/docs/file-based-configuration.md
@@ -92,6 +92,7 @@ distribution:
           # If omitted or null, 10000 is used.
           sampling_interval: 10000
         # Configure memory allocation profiler
+        # Memory profiling is not supported on .NET Framework.
         memory_profiler:
           # Configure maximum memory samples collected per minute. 
           # Maximum value is 500.
@@ -136,6 +137,7 @@ distribution:
         # Configure CPU stack profiler with default settings
         cpu_profiler:
         # Configure Memory allocation profiler with default settings
+        # Memory profiling is not supported on .NET Framework.
         memory_profiler:
       # Configure Callgraph snapshot profiler with default settings
       callgraphs:
@@ -188,6 +190,7 @@ distribution:
           # If omitted or null, 10000 is used.
           sampling_interval: ${SPLUNK_PROFILER_CALL_STACK_INTERVAL}
         # Configure memory allocation profiler
+        # Memory profiling is not supported on .NET Framework.
         memory_profiler:
           # Configure maximum memory samples collected per minute. 
           # Maximum value is 500.

--- a/docs/opamp-config.md
+++ b/docs/opamp-config.md
@@ -31,3 +31,6 @@ When enabled, the OpAMP configuration includes the values for the following sett
 - `OTEL_EXPORTER_OTLP_METRICS_ENDPOINTS`
 - `OTEL_EXPORTER_OTLP_LOGS_ENDPOINTS`
 - `OTEL_SERVICE_NAME`
+
+For .NET Framework applications, `SPLUNK_PROFILER_MEMORY_ENABLED` is always
+reported as `false` because memory profiling is not supported on .NET Framework.

--- a/tools/MatrixHelper/SettingsData.cs
+++ b/tools/MatrixHelper/SettingsData.cs
@@ -76,7 +76,7 @@ internal static class SettingsData
 
             // profiling
             new("SPLUNK_PROFILER_ENABLED", "Activates AlwaysOn Profiling.", "false", "boolean", ProfilingCategory),
-            new("SPLUNK_PROFILER_MEMORY_ENABLED", "Activates memory profiling.", "false", "boolean", ProfilingCategory),
+            new("SPLUNK_PROFILER_MEMORY_ENABLED", "Activates memory profiling. Not supported on .NET Framework.", "false", "boolean", ProfilingCategory),
             new("SPLUNK_PROFILER_LOGS_ENDPOINT", "The collector endpoint for profiler logs.", "http://localhost:4318/v1/logs", "string", ProfilingCategory),
             new("SPLUNK_PROFILER_CALL_STACK_INTERVAL", "Frequency with which call stacks are sampled, in milliseconds.", "10000", "int", ProfilingCategory),
             new("SPLUNK_PROFILER_EXPORT_TIMEOUT", "Export timeout, in milliseconds.", "3000", "int", ProfilingCategory),


### PR DESCRIPTION
Documentation updates:

* Added comments in the file-based configuration documentation  to state that memory profiling is not supported on .NET Framework in all relevant configuration examples.
* Updated the OpAMP configuration documentation to note that `SPLUNK_PROFILER_MEMORY_ENABLED` is always reported as `false` for .NET Framework applications.
* Updated the description for the `SPLUNK_PROFILER_MEMORY_ENABLED`  to indicate that memory profiling is not supported on .NET Framework.