### PR TITLE
config_extension_feature- add support for extended settings like disa…

### DIFF
--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Configuration/FileBasedConfiguration/ProfilerConfiguration.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Configuration/FileBasedConfiguration/ProfilerConfiguration.cs
@@ -27,4 +27,6 @@ internal class ProfilerConfiguration
     public AlwaysOn? AlwaysOn { get; set; }
 
     public CallGraphsConfiguration? Callgraphs { get; set; }
+
+    public bool NativeExportsResolutionEnabled { get; set; } = true;
 }

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/ConfigurationKeys.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/ConfigurationKeys.cs
@@ -85,6 +85,13 @@ internal static class ConfigurationKeys
             /// Configuration key for Profiler exporter export interval (in ms). Defaults to 500 ms, which is also the minimum.
             /// </summary>
             public const string ProfilerExportInterval = "SPLUNK_PROFILER_EXPORT_INTERVAL";
+
+            /// <summary>
+            /// Configuration key for enabling native exports resolution in the continuous profiler.
+            /// Defaults to <c>true</c> When <c>false</c>, the profiler will not attempt to
+            /// resolve native frame exports during sample post-processing.
+            /// </summary>
+            public const string NativeExportsResolutionEnabled = "SPLUNK_PROFILER_NATIVE_EXPORTS_RESOLUTION_ENABLED";
         }
 
         public static class Snapshots

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/Plugin.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/Plugin.cs
@@ -233,6 +233,15 @@ public class Plugin
     }
 
     /// <summary>
+    /// Returns optional extensions for the continuous profiler configuration.
+    /// Newer consumers can discover this method (and the methods on the returned object)
+    /// via reflection. Older consumers that don't know about it will simply use their
+    /// own defaults, preserving backward compatibility.
+    /// </summary>
+    /// <returns>An opaque object exposing additional profiler configuration knobs.</returns>
+    public object GetContinuousProfilerConfigurationExtensions() => new ProfilerExtensions(Settings);
+
+    /// <summary>
     /// Modify SDK config.
     /// </summary>
     /// <param name="builder">TracerProviderBuilder instance to customize.</param>
@@ -321,5 +330,19 @@ public class Plugin
     private static PprofInOtlpLogsExporter CreatePprofInOtlpLogsExporter()
     {
         return new PprofInOtlpLogsExporter(new SampleProcessor(), new SampleExporter(new OtlpHttpLogSender(Settings.ProfilerLogsEndpoint)), new NativeFormatParser(Settings.SnapshotsEnabled));
+    }
+
+    private sealed class ProfilerExtensions
+    {
+        private readonly PluginSettings _settings;
+
+        public ProfilerExtensions(PluginSettings settings)
+        {
+            _settings = settings;
+        }
+
+        // Opt-in by default. Consumers that don't find this method via reflection
+        // will fall back to their own default (also true), so behavior is preserved.
+        public bool GetNativeExportResolutionEnabled() => _settings.NativeExportsResolutionEnabled;
     }
 }

--- a/src/Splunk.OpenTelemetry.AutoInstrumentation/PluginSettings.cs
+++ b/src/Splunk.OpenTelemetry.AutoInstrumentation/PluginSettings.cs
@@ -68,6 +68,8 @@ internal class PluginSettings
         ProfilerExportInterval = GetFinalExportInterval(exportInterval);
 
         ProfilerLogsEndpoint = GetProfilerLogsEndpoints(source, otlpEndpoint == null ? null : new Uri(otlpEndpoint));
+
+        NativeExportsResolutionEnabled = source.GetBool(ConfigurationKeys.Splunk.AlwaysOnProfiler.NativeExportsResolutionEnabled) ?? true;
     }
 
     internal PluginSettings(YamlRoot configuration)
@@ -121,6 +123,8 @@ internal class PluginSettings
             ProfilerHttpClientTimeout = profilingConfig.Exporter.OtlpLogHttp.ExportTimeout;
             ProfilerExportInterval = GetFinalExportInterval((int)profilingConfig.Exporter.OtlpLogHttp.ScheduleDelay);
             ProfilerLogsEndpoint = new Uri(profilingConfig.Exporter.OtlpLogHttp.Endpoint);
+
+            NativeExportsResolutionEnabled = profilingConfig.NativeExportsResolutionEnabled;
         }
     }
 
@@ -155,6 +159,8 @@ internal class PluginSettings
     public uint ProfilerHttpClientTimeout { get; }
 
     public uint ProfilerExportInterval { get; }
+
+    public bool NativeExportsResolutionEnabled { get; }
 
     public static PluginSettings FromDefaultSources()
     {


### PR DESCRIPTION
Adds a forward-compatible profiler config extension surface so hosts can opt out of native frame export resolution without breaking older plugin consumers. Introduces Plugin.GetContinuousProfilerConfigurationExtensions() returning an Object whose GetNativeExportResolutionEnabled() method is discovered via reflection — older hosts that don't know about it transparently fall back to their own defaults. The new knob is sourced from either the SPLUNK_PROFILER_NATIVE_EXPORTS_RESOLUTION_ENABLED environment variable or the native_exports_resolution_enabled YAML key under Profiling, defaulting to true (opt-out) in both paths. Wired through PluginSettings, ConfigurationKeys, and ProfilerConfiguration, with unit tests covering the env-var/YAML default matrix and a reflection smoke test guarding the public contract.
