### PR TITLE
Introduce SPLUNK_VERSION file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This release is built on top of [OpenTelemetry .NET Auto Instrumentation v1.16.0
 ### Added
 
 - Experimental support for effective configuration reporting using OpAmp client.
+- Distribution zip files contain `SPLUNK_VERSION` file. It contains the version
+  and source reference of Splunk Distribution of OpenTelemetry .NET Automatic
+  Instrumentation. `VERSION` file keeps the data for the upstream OpenTelemetry
+  .NET Auto Instrumentation distribution.
 
 ### Changed
 

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -218,6 +218,7 @@ Copyright The OpenTelemetry Authors under Apache License Version 2.0
 
     Target RunIntegrationTests => _ => _
         .After(Compile)
+        .After(CreateSplunkVersionFile)
         .After(AddSplunkPlugins)
         .Executes(() =>
         {

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -162,9 +162,28 @@ Copyright The OpenTelemetry Authors under Apache License Version 2.0
             }
         });
 
+    Target CreateSplunkVersionFile => _ => _
+        .Unlisted()
+        .After(UnpackAutoInstrumentationDistribution)
+        .Executes(() =>
+        {
+            var version = VersionHelper.GetVersion();
+            var refName = "local-dev";
+            var gitSha = VersionHelper.GetCommitId();
+
+            if (Environment.GetEnvironmentVariable("GITHUB_ACTIONS") is "true")
+            {
+                refName = Environment.GetEnvironmentVariable("GITHUB_REF_NAME");
+            }
+
+            var dest = OpenTelemetryDistributionFolder / "SPLUNK_VERSION";
+            dest.WriteAllLines([version, $"{refName}@{gitSha}"]);
+        });
+
     Target PackSplunkDistribution => _ => _
         .After(CopyInstrumentScripts)
         .After(ExtendLicenseFile)
+        .After(CreateSplunkVersionFile)
         .Executes(() =>
         {
             var fileName = GetOTelAutoInstrumentationFileName();
@@ -222,6 +241,7 @@ Copyright The OpenTelemetry Authors under Apache License Version 2.0
         .DependsOn(AddSplunkPlugins)
         .DependsOn(CopyInstrumentScripts)
         .DependsOn(ExtendLicenseFile)
+        .DependsOn(CreateSplunkVersionFile)
         .DependsOn(RunUnitTests)
         .DependsOn(RunIntegrationTests)
         .DependsOn(PackSplunkDistribution);

--- a/build/VersionHelper.cs
+++ b/build/VersionHelper.cs
@@ -3,12 +3,16 @@ using System.Reflection;
 public static class VersionHelper
 {
     static Lazy<string> Version = new Lazy<string>(() =>
-        typeof(VersionHelper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion
-            .Split('+')[0]);
+        typeof(VersionHelper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion);
 
     public static string GetVersion()
     {
-        return Version.Value;
+        return Version.Value.Split('+')[0];
+    }
+
+    public static string GetCommitId()
+    {
+        return Version.Value.Split('+')[1];
     }
 
     public static string GetVersionWithoutSuffixes()

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/BuildTests.DistributionStructure_alpine-linux-arm64.verified.txt
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/BuildTests.DistributionStructure_alpine-linux-arm64.verified.txt
@@ -1,5 +1,6 @@
 ﻿[
   /LICENSE,
+  /SPLUNK_VERSION,
   /VERSION,
   /instrument.sh,
   /linux-musl-arm64/OpenTelemetry.AutoInstrumentation.Native.so,

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/BuildTests.DistributionStructure_alpine-linux-x64.verified.txt
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/BuildTests.DistributionStructure_alpine-linux-x64.verified.txt
@@ -1,5 +1,6 @@
 ﻿[
   /LICENSE,
+  /SPLUNK_VERSION,
   /VERSION,
   /instrument.sh,
   /linux-musl-x64/OpenTelemetry.AutoInstrumentation.Native.so,

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/BuildTests.DistributionStructure_linux-arm64.verified.txt
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/BuildTests.DistributionStructure_linux-arm64.verified.txt
@@ -1,5 +1,6 @@
 ﻿[
   /LICENSE,
+  /SPLUNK_VERSION,
   /VERSION,
   /instrument.sh,
   /linux-arm64/OpenTelemetry.AutoInstrumentation.Native.so,

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/BuildTests.DistributionStructure_linux-x64.verified.txt
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/BuildTests.DistributionStructure_linux-x64.verified.txt
@@ -1,5 +1,6 @@
 ﻿[
   /LICENSE,
+  /SPLUNK_VERSION,
   /VERSION,
   /instrument.sh,
   /linux-x64/OpenTelemetry.AutoInstrumentation.Native.so,

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/BuildTests.DistributionStructure_osx.verified.txt
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/BuildTests.DistributionStructure_osx.verified.txt
@@ -1,5 +1,6 @@
 ﻿[
   /LICENSE,
+  /SPLUNK_VERSION,
   /VERSION,
   /instrument.sh,
   /net/Google.Protobuf.dll,

--- a/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/BuildTests.DistributionStructure_windows.verified.txt
+++ b/test/Splunk.OpenTelemetry.AutoInstrumentation.IntegrationTests/BuildTests.DistributionStructure_windows.verified.txt
@@ -1,5 +1,6 @@
 ﻿[
   \LICENSE,
+  \SPLUNK_VERSION,
   \VERSION,
   \instrument.sh,
   \net\Google.Protobuf.dll,


### PR DESCRIPTION
Use the same functionality as in upstream https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/4775

Our customer mentioned that the VERSION conflict is misleding.