### PR TITLE
[docs] drop microservices-demo from releasing process

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -41,8 +41,6 @@ No changes in the code are needed to correctly version this package.
        to update matrix in [o11y-gdi-metadata repository](https://github.com/splunk/o11y-gdi-metadata/tree/main/apm/splunk-otel-dotnet),
     1. to publish necessary updates to the [documentation](https://github.com/splunk/public-o11y-docs).
 
-1. Update version in [microservices-demo](https://github.com/signalfx/microservices-demo/blob/main/src/cartservice/Dockerfile).
-
 1. Update version in [tracing-examples](https://github.com/signalfx/tracing-examples):
     1. [automatic](https://github.com/signalfx/tracing-examples/blob/main/opentelemetry-tracing/opentelemetry-dotnet/automatic/aspnetcore-and-mongodb/InstrumentContainer/Dockerfile)
     1. [log example](https://github.com/signalfx/tracing-examples/edit/main/opentelemetry-tracing/opentelemetry-dotnet/log-trace-correlation/Dockerfile)


### PR DESCRIPTION
Repo is already archive. PR: https://github.com/signalfx/microservices-demo/pull/164