### PR TITLE
Release 1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this component are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/signalfx/splunk-otel-dotnet/compare/v1.14.0...HEAD)
+## [Unreleased](https://github.com/signalfx/splunk-otel-dotnet/compare/v1.15.0...HEAD)
+
+## [1.15.0](https://github.com/signalfx/splunk-otel-dotnet/compare/v1.15.0)
 
 This release is built on top of [OpenTelemetry .NET Auto Instrumentation v1.16.0](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v1.16.0).
 
@@ -32,14 +34,14 @@ This release is built on top of [OpenTelemetry .NET Auto Instrumentation v1.16.0
 
 ### Security
 
-## [1.14.0](https://github.com/signalfx/splunk-otel-dotnet/compare/v1.14.0...HEAD)
+## [1.14.0](https://github.com/signalfx/splunk-otel-dotnet/releases/tag/v1.14.0)
 
 This release is built on top of [OpenTelemetry .NET Auto Instrumentation v1.15.0](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v1.15.0).
 
 This release includes all changes from [1.14.0-beta.1](https://github.com/signalfx/splunk-otel-dotnet/releases/tag/v1.12.0-beta.1)
 release.
 
-## [1.14.0-beta.1](https://github.com/signalfx/splunk-otel-dotnet/compare/v1.14.0-beta.1...HEAD)
+## [1.14.0-beta.1](https://github.com/signalfx/splunk-otel-dotnet/releases/tag/v1.14.0-beta.1)
 
 This release is built on top of [OpenTelemetry .NET Auto Instrumentation v1.15.0-beta.1](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v1.15.0-beta.1).
 
@@ -51,7 +53,7 @@ This release is built on top of [OpenTelemetry .NET Auto Instrumentation v1.15.0
   instead of baggage propagation,
   with a default selection probability of `0.01` and supported range of `(0.0, 1.0]`.
 
-## [1.13.0](https://github.com/signalfx/splunk-otel-dotnet/compare/v1.13.0...HEAD)
+## [1.13.0](https://github.com/signalfx/splunk-otel-dotnet/releases/tag/v1.13.0)
 
 This release is built on top of [OpenTelemetry .NET Auto Instrumentation v1.14.1](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v1.14.1).
 


### PR DESCRIPTION
This release is built on top of [OpenTelemetry .NET Auto Instrumentation v1.16.0](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v1.16.0).

### Added

- Experimental support for effective configuration reporting using OpAmp client.
- Distribution zip files contain `SPLUNK_VERSION` file. It contains the version
  and source reference of Splunk Distribution of OpenTelemetry .NET Automatic
  Instrumentation. `VERSION` file keeps the data for the upstream OpenTelemetry
  .NET Auto Instrumentation distribution.

### Removed

- `instrument.sh` no longer supports launching an application when the script
  is sourced (for example, `. ./instrument.sh <command>`). To launch an
  application, execute the script directly:
  `./instrument.sh <application_executable>`.

I fixed the links in changelog for previous releases as well.