### PR TITLE
dotnet-install script hardening

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.sh text eol=lf
 *.sh.template text eol=lf
 *.bash text eol=lf
+scripts/dotnet-install.ps1 text eol=lf

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -17,4 +17,4 @@ jobs:
         run: sudo apt update && sudo apt install --assume-yes shellcheck
 
       - name: Run shellcheck
-        run: find . -name \*.sh -o -name \*.sh.template  | xargs shellcheck --severity=warning
+        run: find . -name \*.sh -o -name \*.sh.template | grep -v scripts/dotnet-install.sh | xargs shellcheck --severity=warning

--- a/build.ps1
+++ b/build.ps1
@@ -17,6 +17,7 @@ $BuildProjectFile = "$PSScriptRoot\build\_build.csproj"
 $TempDirectory = "$PSScriptRoot\\.nuke\temp"
 
 $DotNetGlobalFile = "$PSScriptRoot\\global.json"
+$DotNetInstallFileDefault = "$PSScriptRoot\scripts\dotnet-install.ps1"
 $DotNetInstallUrl = "https://dot.net/v1/dotnet-install.ps1"
 $DotNetChannel = "STS"
 
@@ -38,11 +39,11 @@ if ($null -ne (Get-Command "dotnet" -ErrorAction SilentlyContinue) -and `
     $env:DOTNET_EXE = (Get-Command "dotnet").Path
 }
 else {
-    # Download install script
-    $DotNetInstallFile = "$TempDirectory\dotnet-install.ps1"
-    New-Item -ItemType Directory -Path $TempDirectory -Force | Out-Null
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    (New-Object System.Net.WebClient).DownloadFile($DotNetInstallUrl, $DotNetInstallFile)
+    # Use local install script (preferred) or explicit override
+    $DotNetInstallFile = if (Test-Path env:DOTNET_INSTALL_FILE) { $env:DOTNET_INSTALL_FILE } else { $DotNetInstallFileDefault }
+    if (!(Test-Path $DotNetInstallFile)) {
+        throw "dotnet installer script not found: $DotNetInstallFile`nPlace a trusted copy at scripts/dotnet-install.ps1 (or set DOTNET_INSTALL_FILE).`nReference URL for obtaining the script: $DotNetInstallUrl"
+    }
 
     # If global.json exists, load expected version
     if (Test-Path $DotNetGlobalFile) {

--- a/build.sh
+++ b/build.sh
@@ -13,6 +13,7 @@ BUILD_PROJECT_FILE="$SCRIPT_DIR/build/_build.csproj"
 TEMP_DIRECTORY="$SCRIPT_DIR//.nuke/temp"
 
 DOTNET_GLOBAL_FILE="$SCRIPT_DIR//global.json"
+DOTNET_INSTALL_FILE_DEFAULT="$SCRIPT_DIR/scripts/dotnet-install.sh"
 DOTNET_INSTALL_URL="https://dot.net/v1/dotnet-install.sh"
 DOTNET_CHANNEL="STS"
 
@@ -32,10 +33,14 @@ if [ -x "$(command -v dotnet)" ] && dotnet --version &>/dev/null; then
     DOTNET_EXE="$(command -v dotnet)"
     export DOTNET_EXE
 else
-    # Download install script
-    DOTNET_INSTALL_FILE="$TEMP_DIRECTORY/dotnet-install.sh"
-    mkdir -p "$TEMP_DIRECTORY"
-    curl -Lsfo "$DOTNET_INSTALL_FILE" "$DOTNET_INSTALL_URL"
+    # Use local install script (preferred) or explicit override
+    DOTNET_INSTALL_FILE="${DOTNET_INSTALL_FILE:-$DOTNET_INSTALL_FILE_DEFAULT}"
+    if [[ ! -f "$DOTNET_INSTALL_FILE" ]]; then
+        echo "dotnet installer script not found: $DOTNET_INSTALL_FILE" >&2
+        echo "Place a trusted copy at scripts/dotnet-install.sh (or set DOTNET_INSTALL_FILE)." >&2
+        echo "Reference URL for obtaining the script: $DOTNET_INSTALL_URL" >&2
+        exit 1
+    fi
     chmod +x "$DOTNET_INSTALL_FILE"
 
     # If global.json exists, load expected version

--- a/build.sh
+++ b/build.sh
@@ -41,8 +41,6 @@ else
         echo "Reference URL for obtaining the script: $DOTNET_INSTALL_URL" >&2
         exit 1
     fi
-    chmod +x "$DOTNET_INSTALL_FILE"
-
     # If global.json exists, load expected version
     if [[ -f "$DOTNET_GLOBAL_FILE" ]]; then
         DOTNET_VERSION=$(FirstJsonValue "version" "$(cat "$DOTNET_GLOBAL_FILE")")
@@ -54,9 +52,9 @@ else
     # Install by channel or version
     DOTNET_DIRECTORY="$TEMP_DIRECTORY/dotnet-unix"
     if [[ -z ${DOTNET_VERSION+x} ]]; then
-        "$DOTNET_INSTALL_FILE" --install-dir "$DOTNET_DIRECTORY" --channel "$DOTNET_CHANNEL" --no-path
+        bash "$DOTNET_INSTALL_FILE" --install-dir "$DOTNET_DIRECTORY" --channel "$DOTNET_CHANNEL" --no-path
     else
-        "$DOTNET_INSTALL_FILE" --install-dir "$DOTNET_DIRECTORY" --version "$DOTNET_VERSION" --no-path
+        bash "$DOTNET_INSTALL_FILE" --install-dir "$DOTNET_DIRECTORY" --version "$DOTNET_VERSION" --no-path
     fi
     export DOTNET_EXE="$DOTNET_DIRECTORY/dotnet"
     export PATH="$DOTNET_DIRECTORY:$PATH"

--- a/docs/bump-upstream.md
+++ b/docs/bump-upstream.md
@@ -15,6 +15,9 @@
    - [`splunk-otel-dotnet-install.sh.template`](../script-templates/splunk-otel-dotnet-install.sh.template)
    - [`Splunk.OTel.DotNet.psm1.template`](../script-templates/Splunk.OTel.DotNet.psm1.template)
 
+1. Update [`dotnet-install.sh`](../scripts/dotnet-install.sh) based onthe upstream version.
+   Upstream has script updating this script montly.
+
 1. Update [compatibility Matrix data](../tools/MatrixHelper) for
 
     - dependency:

--- a/docs/bump-upstream.md
+++ b/docs/bump-upstream.md
@@ -15,8 +15,8 @@
    - [`splunk-otel-dotnet-install.sh.template`](../script-templates/splunk-otel-dotnet-install.sh.template)
    - [`Splunk.OTel.DotNet.psm1.template`](../script-templates/Splunk.OTel.DotNet.psm1.template)
 
-1. Update [`dotnet-install.sh`](../scripts/dotnet-install.sh) based on the upstream version.
-   Upstream has a script updating this script monthly.
+1. Update [`dotnet-install.sh`](../scripts/dotnet-install.sh) based
+    on the upstream version. Upstream has a script updating this script monthly.
 
 1. Update [compatibility Matrix data](../tools/MatrixHelper) for
 

--- a/docs/bump-upstream.md
+++ b/docs/bump-upstream.md
@@ -15,8 +15,11 @@
    - [`splunk-otel-dotnet-install.sh.template`](../script-templates/splunk-otel-dotnet-install.sh.template)
    - [`Splunk.OTel.DotNet.psm1.template`](../script-templates/Splunk.OTel.DotNet.psm1.template)
 
-1. Update [`dotnet-install.sh`](../scripts/dotnet-install.sh) based
-    on the upstream version. Upstream has a script updating this script monthly.
+1. Update [`dotnet-install.sh`](../scripts/dotnet-install.sh) and
+   [`dotnet-install.ps1`](../scripts/dotnet-install.ps1) based on the upstream
+   versions. Update [`dotnet-install.MIT.txt`](../scripts/dotnet-install.MIT.txt)
+   with the source revision and checksums. Upstream has a script updating these
+   scripts monthly.
 
 1. Update [compatibility Matrix data](../tools/MatrixHelper) for
 

--- a/docs/bump-upstream.md
+++ b/docs/bump-upstream.md
@@ -15,8 +15,8 @@
    - [`splunk-otel-dotnet-install.sh.template`](../script-templates/splunk-otel-dotnet-install.sh.template)
    - [`Splunk.OTel.DotNet.psm1.template`](../script-templates/Splunk.OTel.DotNet.psm1.template)
 
-1. Update [`dotnet-install.sh`](../scripts/dotnet-install.sh) based onthe upstream version.
-   Upstream has script updating this script montly.
+1. Update [`dotnet-install.sh`](../scripts/dotnet-install.sh) based on the upstream version.
+   Upstream has a script updating this script monthly.
 
 1. Update [compatibility Matrix data](../tools/MatrixHelper) for
 

--- a/scripts/dotnet-install.MIT.txt
+++ b/scripts/dotnet-install.MIT.txt
@@ -29,7 +29,7 @@ Source repository: https://github.com/dotnet/install-scripts
 Source revision: 47940ac9fc30a2f2dd19167165d0bb0774625f67
 Source paths: src/dotnet-install.sh and src/dotnet-install.ps1
 
-SHA-256 checksums of the vendored files:
+SHA-256 checksums of the vendored files after LF normalization:
 
   dotnet-install.sh  082f7685e156738a1b2e2ed8381a621870d4ce8e8c59278034556f05c186eb2e
-  dotnet-install.ps1 e8b873e18a81e5c4cd8ab69d84dac8fead291d50b3c44633cd7fddad709a13d6
+  dotnet-install.ps1 718a265ca5ae2acee0fc1e8b5146e32a8d535f8d666e3f7c875d9606c3753987

--- a/scripts/dotnet-install.MIT.txt
+++ b/scripts/dotnet-install.MIT.txt
@@ -1,0 +1,35 @@
+MIT License
+
+Copyright (c) .NET Foundation and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+The following files are vendored copies of the .NET install scripts:
+
+  scripts/dotnet-install.sh
+  scripts/dotnet-install.ps1
+
+Source repository: https://github.com/dotnet/install-scripts
+Source revision: 47940ac9fc30a2f2dd19167165d0bb0774625f67
+Source paths: src/dotnet-install.sh and src/dotnet-install.ps1
+
+SHA-256 checksums of the vendored files:
+
+  dotnet-install.sh  082f7685e156738a1b2e2ed8381a621870d4ce8e8c59278034556f05c186eb2e
+  dotnet-install.ps1 e8b873e18a81e5c4cd8ab69d84dac8fead291d50b3c44633cd7fddad709a13d6

--- a/scripts/dotnet-install.ps1
+++ b/scripts/dotnet-install.ps1
@@ -1,0 +1,1699 @@
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+<#
+.SYNOPSIS
+    Installs dotnet cli
+.DESCRIPTION
+    Installs dotnet cli. If dotnet installation already exists in the given directory
+    it will update it only if the requested version differs from the one already installed.
+
+    Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
+    - The SDK needs to be installed without user interaction and without admin rights.
+    - The SDK installation doesn't need to persist across multiple CI runs.
+    To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.
+
+.PARAMETER Channel
+    Default: LTS
+    Download from the Channel specified. Possible values:
+    - STS - the most recent Standard Term Support release
+    - LTS - the most recent Long Term Support release
+    - 2-part version in a format A.B - represents a specific release
+          examples: 2.0, 1.0
+    - 3-part version in a format A.B.Cxx - represents a specific SDK release
+          examples: 5.0.1xx, 5.0.2xx
+          Supported since 5.0 release
+    Warning: Value "Current" is deprecated for the Channel parameter. Use "STS" instead.
+    Note: The version parameter overrides the channel parameter when any version other than 'latest' is used.
+.PARAMETER Quality
+    Download the latest build of specified quality in the channel. The possible values are: daily, preview, GA.
+    Works only in combination with channel. Not applicable for STS and LTS channels and will be ignored if those channels are used. 
+    Supported since 5.0 release.
+    Note: The version parameter overrides the channel parameter when any version other than 'latest' is used, and therefore overrides the quality.     
+.PARAMETER Version
+    Default: latest
+    Represents a build version on specific channel. Possible values:
+    - latest - the latest build on specific channel
+    - 3-part version in a format A.B.C - represents specific version of build
+          examples: 2.0.0-preview2-006120, 1.1.0
+.PARAMETER Internal
+    Download internal builds. Requires providing credentials via -FeedCredential parameter.
+.PARAMETER FeedCredential
+    Token to access Azure feed. Used as a query string to append to the Azure feed.
+    This parameter typically is not specified.
+.PARAMETER InstallDir
+    Default: %LocalAppData%\Microsoft\dotnet
+    Path to where to install dotnet. Note that binaries will be placed directly in a given directory.
+.PARAMETER Architecture
+    Default: <auto> - this value represents currently running OS architecture
+    Architecture of dotnet binaries to be installed.
+    Possible values are: <auto>, amd64, x64, x86, arm64, arm
+.PARAMETER SharedRuntime
+    This parameter is obsolete and may be removed in a future version of this script.
+    The recommended alternative is '-Runtime dotnet'.
+    Installs just the shared runtime bits, not the entire SDK.
+.PARAMETER Runtime
+    Installs just a shared runtime, not the entire SDK.
+    Possible values:
+        - dotnet     - the Microsoft.NETCore.App shared runtime
+        - aspnetcore - the Microsoft.AspNetCore.App shared runtime
+        - windowsdesktop - the Microsoft.WindowsDesktop.App shared runtime
+.PARAMETER DryRun
+    If set it will not perform installation but instead display what command line to use to consistently install
+    currently requested version of dotnet cli. In example if you specify version 'latest' it will display a link
+    with specific version so that this command can be used deterministically in a build script.
+    It also displays binaries location if you prefer to install or download it yourself.
+.PARAMETER NoPath
+    By default this script will set environment variable PATH for the current process to the binaries folder inside installation folder.
+    If set it will display binaries location but not set any environment variable.
+.PARAMETER Verbose
+    Displays diagnostics information.
+.PARAMETER AzureFeed
+    Default: https://builds.dotnet.microsoft.com/dotnet
+    For internal use only.
+    Allows using a different storage to download SDK archives from.
+.PARAMETER UncachedFeed
+    For internal use only.
+    Allows using a different storage to download SDK archives from.
+.PARAMETER ProxyAddress
+    If set, the installer will use the proxy when making web requests
+.PARAMETER ProxyUseDefaultCredentials
+    Default: false
+    Use default credentials, when using proxy address.
+.PARAMETER ProxyBypassList
+    If set with ProxyAddress, will provide the list of comma separated urls that will bypass the proxy
+.PARAMETER SkipNonVersionedFiles
+    Default: false
+    Skips installing non-versioned files if they already exist, such as dotnet.exe.
+.PARAMETER JSonFile
+    Determines the SDK version from a user specified global.json file
+    Note: global.json must have a value for 'SDK:Version'
+.PARAMETER DownloadTimeout
+    Determines timeout duration in seconds for downloading of the SDK file
+    Default: 1200 seconds (20 minutes)
+.PARAMETER KeepZip
+    If set, downloaded archive file is kept. Applies to both .zip and .tar.gz formats.
+.PARAMETER ZipPath
+    Use that path to store the downloaded archive, generated by default. Applies to both .zip and .tar.gz formats.
+.EXAMPLE
+    dotnet-install.ps1 -Version 7.0.401
+    Installs the .NET SDK version 7.0.401
+.EXAMPLE
+    dotnet-install.ps1 -Channel 8.0 -Quality GA
+    Installs the latest GA (general availability) version of the .NET 8.0 SDK
+#>
+[cmdletbinding()]
+param(
+    [string]$Channel = "LTS",
+    [string]$Quality,
+    [string]$Version = "Latest",
+    [switch]$Internal,
+    [string]$JSonFile,
+    [Alias('i')][string]$InstallDir = "<auto>",
+    [string]$Architecture = "<auto>",
+    [string]$Runtime,
+    [Obsolete("This parameter may be removed in a future version of this script. The recommended alternative is '-Runtime dotnet'.")]
+    [switch]$SharedRuntime,
+    [switch]$DryRun,
+    [switch]$NoPath,
+    [string]$AzureFeed,
+    [string]$UncachedFeed,
+    [string]$FeedCredential,
+    [string]$ProxyAddress,
+    [switch]$ProxyUseDefaultCredentials,
+    [string[]]$ProxyBypassList = @(),
+    [switch]$SkipNonVersionedFiles,
+    [int]$DownloadTimeout = 1200,
+    [switch]$KeepZip,
+    [string]$ZipPath = [System.IO.Path]::combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName()),
+    [switch]$Help
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+function Say($str) {
+    try {
+        Write-Host "dotnet-install: $str"
+    }
+    catch {
+        # Some platforms cannot utilize Write-Host (Azure Functions, for instance). Fall back to Write-Output
+        Write-Output "dotnet-install: $str"
+    }
+}
+
+function Say-Warning($str) {
+    try {
+        Write-Warning "dotnet-install: $str"
+    }
+    catch {
+        # Some platforms cannot utilize Write-Warning (Azure Functions, for instance). Fall back to Write-Output
+        Write-Output "dotnet-install: Warning: $str"
+    }
+}
+
+# Writes a line with error style settings.
+# Use this function to show a human-readable comment along with an exception.
+function Say-Error($str) {
+    try {
+        # Write-Error is quite verbose for the purpose of the function, let's write one line with error style settings.
+        $Host.UI.WriteErrorLine("dotnet-install: $str")
+    }
+    catch {
+        Write-Output "dotnet-install: Error: $str"
+    }
+}
+
+function Say-Verbose($str) {
+    try {
+        Write-Verbose "dotnet-install: $str"
+    }
+    catch {
+        # Some platforms cannot utilize Write-Verbose (Azure Functions, for instance). Fall back to Write-Output
+        Write-Output "dotnet-install: $str"
+    }
+}
+
+function Measure-Action($name, $block) {
+    $time = Measure-Command $block
+    $totalSeconds = $time.TotalSeconds
+    Say-Verbose "Action '$name' took $totalSeconds seconds"
+}
+
+function Get-Remote-File-Size($zipUri) {
+    try {
+        $response = Invoke-WebRequest -UseBasicParsing -Uri $zipUri -Method Head
+        $fileSize = $response.Headers["Content-Length"]
+        if ((![string]::IsNullOrEmpty($fileSize))) {
+            Say "Remote file $zipUri size is $fileSize bytes."
+        
+            return $fileSize
+        }
+    }
+    catch {
+        Say-Verbose "Content-Length header was not extracted for $zipUri."
+    }
+
+    return $null
+}
+
+function Say-Invocation($Invocation) {
+    $command = $Invocation.MyCommand;
+    $args = (($Invocation.BoundParameters.Keys | foreach { "-$_ `"$($Invocation.BoundParameters[$_])`"" }) -join " ")
+    Say-Verbose "$command $args"
+}
+
+function Invoke-With-Retry([ScriptBlock]$ScriptBlock, [System.Threading.CancellationToken]$cancellationToken = [System.Threading.CancellationToken]::None, [int]$MaxAttempts = 3, [int]$SecondsBetweenAttempts = 1) {
+    $Attempts = 0
+    $local:startTime = $(get-date)
+
+    while ($true) {
+        try {
+            return & $ScriptBlock
+        }
+        catch {
+            $Attempts++
+            if (($Attempts -lt $MaxAttempts) -and -not $cancellationToken.IsCancellationRequested) {
+                Start-Sleep $SecondsBetweenAttempts
+            }
+            else {
+                $local:elapsedTime = $(get-date) - $local:startTime
+                if (($local:elapsedTime.TotalSeconds - $DownloadTimeout) -gt 0 -and -not $cancellationToken.IsCancellationRequested) {
+                    throw New-Object System.TimeoutException("Failed to reach the server: connection timeout: default timeout is $DownloadTimeout second(s)");
+                }
+                throw;
+            }
+        }
+    }
+}
+
+function Get-Machine-Architecture() {
+    Say-Invocation $MyInvocation
+
+    # On PS x86, PROCESSOR_ARCHITECTURE reports x86 even on x64 systems.
+    # To get the correct architecture, we need to use PROCESSOR_ARCHITEW6432.
+    # PS x64 doesn't define this, so we fall back to PROCESSOR_ARCHITECTURE.
+    # Possible values: amd64, x64, x86, arm64, arm
+    if ( $ENV:PROCESSOR_ARCHITEW6432 -ne $null ) {
+        return $ENV:PROCESSOR_ARCHITEW6432
+    }
+
+    try {        
+        if ( ((Get-CimInstance -ClassName CIM_OperatingSystem).OSArchitecture) -like "ARM*") {
+            if ( [Environment]::Is64BitOperatingSystem ) {
+                return "arm64"
+            }  
+            return "arm"
+        }
+    }
+    catch {
+        # Machine doesn't support Get-CimInstance
+    }
+
+    return $ENV:PROCESSOR_ARCHITECTURE
+}
+
+function Get-CLIArchitecture-From-Architecture([string]$Architecture) {
+    Say-Invocation $MyInvocation
+
+    if ($Architecture -eq "<auto>") {
+        $Architecture = Get-Machine-Architecture
+    }
+
+    switch ($Architecture.ToLowerInvariant()) {
+        { ($_ -eq "amd64") -or ($_ -eq "x64") } { return "x64" }
+        { $_ -eq "x86" } { return "x86" }
+        { $_ -eq "arm" } { return "arm" }
+        { $_ -eq "arm64" } { return "arm64" }
+        default { throw "Architecture '$Architecture' not supported. If you think this is a bug, report it at https://github.com/dotnet/install-scripts/issues" }
+    }
+}
+
+function ValidateFeedCredential([string] $FeedCredential) {
+    if ($Internal -and [string]::IsNullOrWhitespace($FeedCredential)) {
+        $message = "Provide credentials via -FeedCredential parameter."
+        if ($DryRun) {
+            Say-Warning "$message"
+        }
+        else {
+            throw "$message"
+        }
+    }
+    
+    #FeedCredential should start with "?", for it to be added to the end of the link.
+    #adding "?" at the beginning of the FeedCredential if needed.
+    if ((![string]::IsNullOrWhitespace($FeedCredential)) -and ($FeedCredential[0] -ne '?')) {
+        $FeedCredential = "?" + $FeedCredential
+    }
+
+    return $FeedCredential
+}
+function Get-NormalizedQuality([string]$Quality) {
+    Say-Invocation $MyInvocation
+
+    if ([string]::IsNullOrEmpty($Quality)) {
+        return ""
+    }
+
+    switch ($Quality) {
+        { @("daily", "preview") -contains $_ } { return $Quality.ToLowerInvariant() }
+        #ga quality is available without specifying quality, so normalizing it to empty
+        { $_ -eq "ga" } { return "" }
+        default { throw "'$Quality' is not a supported value for -Quality option. Supported values are: daily, preview, ga. If you think this is a bug, report it at https://github.com/dotnet/install-scripts/issues." }
+    }
+}
+
+function Get-NormalizedChannel([string]$Channel) {
+    Say-Invocation $MyInvocation
+
+    if ([string]::IsNullOrEmpty($Channel)) {
+        return ""
+    }
+
+    if ($Channel.Contains("Current")) {
+        Say-Warning 'Value "Current" is deprecated for -Channel option. Use "STS" instead.'
+    }
+
+    if ($Channel.StartsWith('release/')) {
+        Say-Warning 'Using branch name with -Channel option is no longer supported with newer releases. Use -Quality option with a channel in X.Y format instead, such as "-Channel 5.0 -Quality Daily."'
+    }
+
+    switch ($Channel) {
+        { $_ -eq "lts" } { return "LTS" }
+        { $_ -eq "sts" } { return "STS" }
+        { $_ -eq "current" } { return "STS" }
+        default { return $Channel.ToLowerInvariant() }
+    }
+}
+
+function Get-NormalizedProduct([string]$Runtime) {
+    Say-Invocation $MyInvocation
+
+    switch ($Runtime) {
+        { $_ -eq "dotnet" } { return "dotnet-runtime" }
+        { $_ -eq "aspnetcore" } { return "aspnetcore-runtime" }
+        { $_ -eq "windowsdesktop" } { return "windowsdesktop-runtime" }
+        { [string]::IsNullOrEmpty($_) } { return "dotnet-sdk" }
+        default { throw "'$Runtime' is not a supported value for -Runtime option, supported values are: dotnet, aspnetcore, windowsdesktop. If you think this is a bug, report it at https://github.com/dotnet/install-scripts/issues." }
+    }
+}
+
+function Test-TarAvailable {
+    if ($env:DOTNET_INSTALL_SKIP_TAR -eq "1") {
+        Say-Verbose "Skipping tar detection due to DOTNET_INSTALL_SKIP_TAR environment variable."
+        return $false
+    }
+    $tarCommand = Get-Command -Name "tar" -ErrorAction SilentlyContinue
+    return $null -ne $tarCommand
+}
+
+function Get-FileExtension-For-Version([string]$VersionOrChannel) {
+    if (-not $script:TarAvailable) {
+        return ".zip"
+    }
+    if ($VersionOrChannel -match '^(\d+)\.') {
+        $majorVersion = [int]$Matches[1]
+        if ($majorVersion -ge 11) {
+            # Windows tarballs are only available starting with 11.0 preview 3
+            if ($VersionOrChannel -match 'preview\.(\d+)') {
+                $previewNum = [int]$Matches[1]
+                if ($majorVersion -eq 11 -and $previewNum -lt 3) {
+                    Say-Verbose "Version '$VersionOrChannel' predates tar.gz availability; using zip."
+                    return ".zip"
+                }
+            }
+            Say-Verbose "Using tar.gz archive format for version/channel '$VersionOrChannel'."
+            return ".tar.gz"
+        }
+    }
+    return ".zip"
+}
+
+# The version text returned from the feeds is a 1-line or 2-line string:
+# For the SDK and the dotnet runtime (2 lines):
+# Line 1: # commit_hash
+# Line 2: # 4-part version
+# For the aspnetcore runtime (1 line):
+# Line 1: # 4-part version
+function Get-Version-From-LatestVersion-File-Content([string]$VersionText) {
+    Say-Invocation $MyInvocation
+
+    $Data = -split $VersionText
+
+    $VersionInfo = @{
+        CommitHash = $(if ($Data.Count -gt 1) { $Data[0] })
+        Version    = $Data[-1] # last line is always the version number.
+    }
+    return $VersionInfo
+}
+
+function Load-Assembly([string] $Assembly) {
+    try {
+        Add-Type -Assembly $Assembly | Out-Null
+    }
+    catch {
+        # On Nano Server, Powershell Core Edition is used.  Add-Type is unable to resolve base class assemblies because they are not GAC'd.
+        # Loading the base class assemblies is not unnecessary as the types will automatically get resolved.
+    }
+}
+
+function GetHTTPResponse([Uri] $Uri, [bool]$HeaderOnly, [bool]$DisableRedirect, [bool]$DisableFeedCredential) {
+    $cts = New-Object System.Threading.CancellationTokenSource
+
+    $downloadScript = {
+
+        $HttpClient = $null
+
+        try {
+            # HttpClient is used vs Invoke-WebRequest in order to support Nano Server which doesn't support the Invoke-WebRequest cmdlet.
+            Load-Assembly -Assembly System.Net.Http
+
+            if (-not $ProxyAddress) {
+                try {
+                    # Despite no proxy being explicitly specified, we may still be behind a default proxy
+                    $DefaultProxy = [System.Net.WebRequest]::DefaultWebProxy;
+                    if ($DefaultProxy -and (-not $DefaultProxy.IsBypassed($Uri))) {
+                        if ($null -ne $DefaultProxy.GetProxy($Uri)) {
+                            $ProxyAddress = $DefaultProxy.GetProxy($Uri).OriginalString
+                        }
+                        else {
+                            $ProxyAddress = $null
+                        }
+                        $ProxyUseDefaultCredentials = $true
+                    }
+                }
+                catch {
+                    # Eat the exception and move forward as the above code is an attempt
+                    #    at resolving the DefaultProxy that may not have been a problem.
+                    $ProxyAddress = $null
+                    Say-Verbose("Exception ignored: $_.Exception.Message - moving forward...")
+                }
+            }
+
+            $HttpClientHandler = New-Object System.Net.Http.HttpClientHandler
+            if ($ProxyAddress) {
+                $HttpClientHandler.Proxy = New-Object System.Net.WebProxy -Property @{
+                    Address               = $ProxyAddress;
+                    UseDefaultCredentials = $ProxyUseDefaultCredentials;
+                    BypassList            = $ProxyBypassList;
+                }
+            }       
+            if ($DisableRedirect) {
+                $HttpClientHandler.AllowAutoRedirect = $false
+            }
+            $HttpClient = New-Object System.Net.Http.HttpClient -ArgumentList $HttpClientHandler
+
+            # Default timeout for HttpClient is 100s.  For a 50 MB download this assumes 500 KB/s average, any less will time out
+            # Defaulting to 20 minutes allows it to work over much slower connections.
+            $HttpClient.Timeout = New-TimeSpan -Seconds $DownloadTimeout
+
+            if ($HeaderOnly) {
+                $completionOption = [System.Net.Http.HttpCompletionOption]::ResponseHeadersRead
+            }
+            else {
+                $completionOption = [System.Net.Http.HttpCompletionOption]::ResponseContentRead
+            }
+
+            if ($DisableFeedCredential) {
+                $UriWithCredential = $Uri
+            }
+            else {
+                $UriWithCredential = "${Uri}${FeedCredential}"
+            }
+
+            $Task = $HttpClient.GetAsync("$UriWithCredential", $completionOption).ConfigureAwait("false");
+            $Response = $Task.GetAwaiter().GetResult();
+
+            if (($null -eq $Response) -or ((-not $HeaderOnly) -and (-not ($Response.IsSuccessStatusCode)))) {
+                # The feed credential is potentially sensitive info. Do not log FeedCredential to console output.
+                $DownloadException = [System.Exception] "Unable to download $Uri."
+
+                if ($null -ne $Response) {
+                    $DownloadException.Data["StatusCode"] = [int] $Response.StatusCode
+                    $DownloadException.Data["ErrorMessage"] = "Unable to download $Uri. Returned HTTP status code: " + $DownloadException.Data["StatusCode"]
+
+                    if (404 -eq [int] $Response.StatusCode) {
+                        $cts.Cancel()
+                    }
+                }
+
+                throw $DownloadException
+            }
+
+            return $Response
+        }
+        catch [System.Net.Http.HttpRequestException] {
+            $DownloadException = [System.Exception] "Unable to download $Uri."
+
+            # Pick up the exception message and inner exceptions' messages if they exist
+            $CurrentException = $PSItem.Exception
+            $ErrorMsg = $CurrentException.Message + "`r`n"
+            while ($CurrentException.InnerException) {
+                $CurrentException = $CurrentException.InnerException
+                $ErrorMsg += $CurrentException.Message + "`r`n"
+            }
+
+            # Check if there is an issue concerning TLS.
+            if ($ErrorMsg -like "*SSL/TLS*") {
+                $ErrorMsg += "Ensure that TLS 1.2 or higher is enabled to use this script.`r`n"
+            }
+
+            $DownloadException.Data["ErrorMessage"] = $ErrorMsg
+            throw $DownloadException
+        }
+        finally {
+            if ($null -ne $HttpClient) {
+                $HttpClient.Dispose()
+            }
+        }
+    }
+
+    try {
+        return Invoke-With-Retry $downloadScript $cts.Token
+    }
+    finally {
+        if ($null -ne $cts) {
+            $cts.Dispose()
+        }
+    }
+}
+
+function Get-Version-From-LatestVersion-File([string]$AzureFeed, [string]$Channel) {
+    Say-Invocation $MyInvocation
+
+    $VersionFileUrl = $null
+    if ($Runtime -eq "dotnet") {
+        $VersionFileUrl = "$AzureFeed/Runtime/$Channel/latest.version"
+    }
+    elseif ($Runtime -eq "aspnetcore") {
+        $VersionFileUrl = "$AzureFeed/aspnetcore/Runtime/$Channel/latest.version"
+    }
+    elseif ($Runtime -eq "windowsdesktop") {
+        $VersionFileUrl = "$AzureFeed/WindowsDesktop/$Channel/latest.version"
+    }
+    elseif (-not $Runtime) {
+        $VersionFileUrl = "$AzureFeed/Sdk/$Channel/latest.version"
+    }
+    else {
+        throw "Invalid value for `$Runtime"
+    }
+
+    Say-Verbose "Constructed latest.version URL: $VersionFileUrl"
+
+    try {
+        $Response = GetHTTPResponse -Uri $VersionFileUrl
+    }
+    catch {
+        Say-Verbose "Failed to download latest.version file."
+        throw
+    }
+    $StringContent = $Response.Content.ReadAsStringAsync().Result
+
+    switch ($Response.Content.Headers.ContentType) {
+        { ($_ -eq "application/octet-stream") } { $VersionText = $StringContent }
+        { ($_ -eq "text/plain") } { $VersionText = $StringContent }
+        { ($_ -eq "text/plain; charset=UTF-8") } { $VersionText = $StringContent }
+        default { throw "``$Response.Content.Headers.ContentType`` is an unknown .version file content type." }
+    }
+
+    $VersionInfo = Get-Version-From-LatestVersion-File-Content $VersionText
+
+    return $VersionInfo
+}
+
+function Parse-Jsonfile-For-Version([string]$JSonFile) {
+    Say-Invocation $MyInvocation
+
+    If (-Not (Test-Path $JSonFile)) {
+        throw "Unable to find '$JSonFile'"
+    }
+    try {
+        $JSonContent = Get-Content($JSonFile) -Raw | ConvertFrom-Json | Select-Object -expand "sdk" -ErrorAction SilentlyContinue
+    }
+    catch {
+        Say-Error "Json file unreadable: '$JSonFile'"
+        throw
+    }
+    if ($JSonContent) {
+        try {
+            $JSonContent.PSObject.Properties | ForEach-Object {
+                $PropertyName = $_.Name
+                if ($PropertyName -eq "version") {
+                    $Version = $_.Value
+                    Say-Verbose "Version = $Version"
+                }
+            }
+        }
+        catch {
+            Say-Error "Unable to parse the SDK node in '$JSonFile'"
+            throw
+        }
+    }
+    else {
+        throw "Unable to find the SDK node in '$JSonFile'"
+    }
+    If ($Version -eq $null) {
+        throw "Unable to find the SDK:version node in '$JSonFile'"
+    }
+    return $Version
+}
+
+function Get-Specific-Version-From-Version([string]$AzureFeed, [string]$Channel, [string]$Version, [string]$JSonFile) {
+    Say-Invocation $MyInvocation
+
+    if (-not $JSonFile) {
+        if ($Version.ToLowerInvariant() -eq "latest") {
+            $LatestVersionInfo = Get-Version-From-LatestVersion-File -AzureFeed $AzureFeed -Channel $Channel
+            return $LatestVersionInfo.Version
+        }
+        else {
+            return $Version 
+        }
+    }
+    else {
+        return Parse-Jsonfile-For-Version $JSonFile
+    }
+}
+
+function Get-Download-Link([string]$AzureFeed, [string]$SpecificVersion, [string]$CLIArchitecture) {
+    Say-Invocation $MyInvocation
+
+    # If anything fails in this lookup it will default to $SpecificVersion
+    $SpecificProductVersion = Get-Product-Version -AzureFeed $AzureFeed -SpecificVersion $SpecificVersion
+
+    # For .NET 11.0+, tar.gz is the preferred archive format on Windows
+    $ext = Get-FileExtension-For-Version $SpecificVersion
+
+    if ($Runtime -eq "dotnet") {
+        $PayloadURL = "$AzureFeed/Runtime/$SpecificVersion/dotnet-runtime-$SpecificProductVersion-win-$CLIArchitecture$ext"
+    }
+    elseif ($Runtime -eq "aspnetcore") {
+        $PayloadURL = "$AzureFeed/aspnetcore/Runtime/$SpecificVersion/aspnetcore-runtime-$SpecificProductVersion-win-$CLIArchitecture$ext"
+    }
+    elseif ($Runtime -eq "windowsdesktop") {
+        # The windows desktop runtime is part of the core runtime layout prior to 5.0
+        $PayloadURL = "$AzureFeed/Runtime/$SpecificVersion/windowsdesktop-runtime-$SpecificProductVersion-win-$CLIArchitecture$ext"
+        if ($SpecificVersion -match '^(\d+)\.(.*)$') {
+            $majorVersion = [int]$Matches[1]
+            if ($majorVersion -ge 5) {
+                $PayloadURL = "$AzureFeed/WindowsDesktop/$SpecificVersion/windowsdesktop-runtime-$SpecificProductVersion-win-$CLIArchitecture$ext"
+            }
+        }
+    }
+    elseif (-not $Runtime) {
+        $PayloadURL = "$AzureFeed/Sdk/$SpecificVersion/dotnet-sdk-$SpecificProductVersion-win-$CLIArchitecture$ext"
+    }
+    else {
+        throw "Invalid value for `$Runtime"
+    }
+
+    Say-Verbose "Constructed primary named payload URL: $PayloadURL"
+
+    return $PayloadURL, $SpecificProductVersion
+}
+
+function Get-LegacyDownload-Link([string]$AzureFeed, [string]$SpecificVersion, [string]$CLIArchitecture) {
+    Say-Invocation $MyInvocation
+
+    if (-not $Runtime) {
+        $PayloadURL = "$AzureFeed/Sdk/$SpecificVersion/dotnet-dev-win-$CLIArchitecture.$SpecificVersion.zip"
+    }
+    elseif ($Runtime -eq "dotnet") {
+        $PayloadURL = "$AzureFeed/Runtime/$SpecificVersion/dotnet-win-$CLIArchitecture.$SpecificVersion.zip"
+    }
+    else {
+        return $null
+    }
+
+    Say-Verbose "Constructed legacy named payload URL: $PayloadURL"
+
+    return $PayloadURL
+}
+
+function Get-Product-Version([string]$AzureFeed, [string]$SpecificVersion, [string]$PackageDownloadLink) {
+    Say-Invocation $MyInvocation
+
+    # Try to get the version number, using the productVersion.txt file located next to the installer file.
+    $ProductVersionTxtURLs = (Get-Product-Version-Url $AzureFeed $SpecificVersion $PackageDownloadLink -Flattened $true),
+                             (Get-Product-Version-Url $AzureFeed $SpecificVersion $PackageDownloadLink -Flattened $false)
+    
+    Foreach ($ProductVersionTxtURL in $ProductVersionTxtURLs) {
+        Say-Verbose "Checking for the existence of $ProductVersionTxtURL"
+
+        try {
+            $productVersionResponse = GetHTTPResponse($productVersionTxtUrl)
+
+            if ($productVersionResponse.StatusCode -eq 200) {
+                $productVersion = $productVersionResponse.Content.ReadAsStringAsync().Result.Trim()
+                if ($productVersion -ne $SpecificVersion) {
+                    Say "Using alternate version $productVersion found in $ProductVersionTxtURL"
+                }
+                return $productVersion
+            }
+            else {
+                Say-Verbose "Got StatusCode $($productVersionResponse.StatusCode) when trying to get productVersion.txt at $productVersionTxtUrl."
+            }
+        } 
+        catch {
+            Say-Verbose "Could not read productVersion.txt at $productVersionTxtUrl (Exception: '$($_.Exception.Message)'. )"
+        }
+    }
+
+    # Getting the version number with productVersion.txt has failed. Try parsing the download link for a version number.
+    if ([string]::IsNullOrEmpty($PackageDownloadLink)) {
+        Say-Verbose "Using the default value '$SpecificVersion' as the product version."
+        return $SpecificVersion
+    }
+
+    $productVersion = Get-ProductVersionFromDownloadLink $PackageDownloadLink $SpecificVersion
+    return $productVersion
+}
+
+function Get-Product-Version-Url([string]$AzureFeed, [string]$SpecificVersion, [string]$PackageDownloadLink, [bool]$Flattened) {
+    Say-Invocation $MyInvocation
+
+    $majorVersion = $null
+    if ($SpecificVersion -match '^(\d+)\.(.*)') {
+        $majorVersion = $Matches[1] -as [int]
+    }
+
+    $pvFileName = 'productVersion.txt'
+    if ($Flattened) {
+        if (-not $Runtime) {
+            $pvFileName = 'sdk-productVersion.txt'
+        }
+        elseif ($Runtime -eq "dotnet") {
+            $pvFileName = 'runtime-productVersion.txt'
+        }
+        else {
+            $pvFileName = "$Runtime-productVersion.txt"
+        }
+    }
+
+    if ([string]::IsNullOrEmpty($PackageDownloadLink)) {
+        if ($Runtime -eq "dotnet") {
+            $ProductVersionTxtURL = "$AzureFeed/Runtime/$SpecificVersion/$pvFileName"
+        }
+        elseif ($Runtime -eq "aspnetcore") {
+            $ProductVersionTxtURL = "$AzureFeed/aspnetcore/Runtime/$SpecificVersion/$pvFileName"
+        }
+        elseif ($Runtime -eq "windowsdesktop") {
+            # The windows desktop runtime is part of the core runtime layout prior to 5.0
+            $ProductVersionTxtURL = "$AzureFeed/Runtime/$SpecificVersion/$pvFileName"
+            if ($majorVersion -ne $null -and $majorVersion -ge 5) {
+                $ProductVersionTxtURL = "$AzureFeed/WindowsDesktop/$SpecificVersion/$pvFileName"
+            }
+        }
+        elseif (-not $Runtime) {
+            $ProductVersionTxtURL = "$AzureFeed/Sdk/$SpecificVersion/$pvFileName"
+        }
+        else {
+            throw "Invalid value '$Runtime' specified for `$Runtime"
+        }
+    }
+    else {
+        $ProductVersionTxtURL = $PackageDownloadLink.Substring(0, $PackageDownloadLink.LastIndexOf("/")) + "/$pvFileName"
+    }
+
+    Say-Verbose "Constructed productVersion link: $ProductVersionTxtURL"
+
+    return $ProductVersionTxtURL
+}
+
+function Get-ProductVersionFromDownloadLink([string]$PackageDownloadLink, [string]$SpecificVersion) {
+    Say-Invocation $MyInvocation
+
+    #product specific version follows the product name
+    #for filename 'dotnet-sdk-3.1.404-win-x64.zip': the product version is 3.1.400
+    $filename = $PackageDownloadLink.Substring($PackageDownloadLink.LastIndexOf("/") + 1)
+    $filenameParts = $filename.Split('-')
+    if ($filenameParts.Length -gt 2) {
+        $productVersion = $filenameParts[2]
+        Say-Verbose "Extracted product version '$productVersion' from download link '$PackageDownloadLink'."
+    }
+    else {
+        Say-Verbose "Using the default value '$SpecificVersion' as the product version."
+        $productVersion = $SpecificVersion
+    }
+    return $productVersion 
+}
+
+function Get-User-Share-Path() {
+    Say-Invocation $MyInvocation
+
+    $InstallRoot = $env:DOTNET_INSTALL_DIR
+    if (!$InstallRoot) {
+        $InstallRoot = "$env:LocalAppData\Microsoft\dotnet"
+    }
+    elseif ($InstallRoot -like "$env:ProgramFiles\dotnet\?*") {
+        Say-Warning "The install root specified by the environment variable DOTNET_INSTALL_DIR points to the sub folder of $env:ProgramFiles\dotnet which is the default dotnet install root using .NET SDK installer. It is better to keep aligned with .NET SDK installer."
+    }
+    return $InstallRoot
+}
+
+function Resolve-Installation-Path([string]$InstallDir) {
+    Say-Invocation $MyInvocation
+
+    if ($InstallDir -eq "<auto>") {
+        return Get-User-Share-Path
+    }
+    return $InstallDir
+}
+
+function Test-User-Write-Access([string]$InstallDir) {
+    try {
+        $tempFileName = [guid]::NewGuid().ToString()
+        $tempFilePath = Join-Path -Path $InstallDir -ChildPath $tempFileName
+        New-Item -Path $tempFilePath -ItemType File -Force
+        Remove-Item $tempFilePath -Force
+        return $true
+    }
+    catch {
+        return $false
+    }
+}
+
+function Is-Dotnet-Package-Installed([string]$InstallRoot, [string]$RelativePathToPackage, [string]$SpecificVersion) {
+    Say-Invocation $MyInvocation
+
+    $DotnetPackagePath = Join-Path -Path $InstallRoot -ChildPath $RelativePathToPackage | Join-Path -ChildPath $SpecificVersion
+    Say-Verbose "Is-Dotnet-Package-Installed: DotnetPackagePath=$DotnetPackagePath"
+    return Test-Path $DotnetPackagePath -PathType Container
+}
+
+function Get-Absolute-Path([string]$RelativeOrAbsolutePath) {
+    # Too much spam
+    # Say-Invocation $MyInvocation
+
+    return $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($RelativeOrAbsolutePath)
+}
+
+function Get-Path-Prefix-With-Version($path) {
+    # example path with regex: shared/1.0.0-beta-12345/somepath
+    $match = [regex]::match($path, "/\d+\.\d+[^/]+/")
+    if ($match.Success) {
+        return $entry.FullName.Substring(0, $match.Index + $match.Length)
+    }
+
+    return $null
+}
+
+function Get-List-Of-Directories-And-Versions-To-Unpack-From-Dotnet-Package([System.IO.Compression.ZipArchive]$Zip, [string]$OutPath) {
+    Say-Invocation $MyInvocation
+
+    $ret = @()
+    foreach ($entry in $Zip.Entries) {
+        $dir = Get-Path-Prefix-With-Version $entry.FullName
+        if ($null -ne $dir) {
+            $path = Get-Absolute-Path $(Join-Path -Path $OutPath -ChildPath $dir)
+            if (-Not (Test-Path $path -PathType Container)) {
+                $ret += $dir
+            }
+        }
+    }
+
+    $ret = $ret | Sort-Object | Get-Unique
+
+    $values = ($ret | foreach { "$_" }) -join ";"
+    Say-Verbose "Directories to unpack: $values"
+
+    return $ret
+}
+
+# Example zip content and extraction algorithm:
+# Rule: files if extracted are always being extracted to the same relative path locally
+# .\
+#       a.exe   # file does not exist locally, extract
+#       b.dll   # file exists locally, override only if $OverrideFiles set
+#       aaa\    # same rules as for files
+#           ...
+#       abc\1.0.0\  # directory contains version and exists locally
+#           ...     # do not extract content under versioned part
+#       abc\asd\    # same rules as for files
+#            ...
+#       def\ghi\1.0.1\  # directory contains version and does not exist locally
+#           ...         # extract content
+function Extract-Dotnet-Package([string]$ZipPath, [string]$OutPath) {
+    Say-Invocation $MyInvocation
+
+    Load-Assembly -Assembly System.IO.Compression.FileSystem
+    Set-Variable -Name Zip
+    try {
+        $Zip = [System.IO.Compression.ZipFile]::OpenRead($ZipPath)
+
+        $DirectoriesToUnpack = Get-List-Of-Directories-And-Versions-To-Unpack-From-Dotnet-Package -Zip $Zip -OutPath $OutPath
+
+        foreach ($entry in $Zip.Entries) {
+            $PathWithVersion = Get-Path-Prefix-With-Version $entry.FullName
+            if (($null -eq $PathWithVersion) -Or ($DirectoriesToUnpack -contains $PathWithVersion)) {
+                $DestinationPath = Get-Absolute-Path $(Join-Path -Path $OutPath -ChildPath $entry.FullName)
+                $DestinationDir = Split-Path -Parent $DestinationPath
+                $OverrideFiles = $OverrideNonVersionedFiles -Or (-Not (Test-Path $DestinationPath))
+                if ((-Not $DestinationPath.EndsWith("\")) -And $OverrideFiles) {
+                    New-Item -ItemType Directory -Force -Path $DestinationDir | Out-Null
+                    [System.IO.Compression.ZipFileExtensions]::ExtractToFile($entry, $DestinationPath, $OverrideNonVersionedFiles)
+                }
+            }
+        }
+    }
+    catch {
+        Say-Error "Failed to extract package. Exception: $_"
+        throw;
+    }
+    finally {
+        if ($null -ne $Zip) {
+            $Zip.Dispose()
+        }
+    }
+}
+
+function Extract-Dotnet-Package-Tar([string]$TarPath, [string]$OutPath) {
+    Say-Invocation $MyInvocation
+
+    New-Item -ItemType Directory -Force -Path $OutPath | Out-Null
+
+    # Build an exclude list of versioned directories that already exist locally.
+    # This matches the zip extraction behavior: if shared/Microsoft.NETCore.App/11.0.0/
+    # already exists, we skip all files under that version to avoid overwriting a
+    # previously installed version.
+    $excludeArgs = @()
+    $versionRegex = '.*/\d+\.\d+[^/]+/'
+
+    # Read the tarball's file listing to discover versioned directory prefixes
+    $tarListing = & tar -tzf $TarPath 2>$null
+    $versionedDirs = @{}
+    foreach ($entry in $tarListing) {
+        $normalizedEntry = $entry.Replace('\', '/')
+        $match = [regex]::Match($normalizedEntry, $versionRegex)
+        if ($match.Success) {
+            $versionedPrefix = $normalizedEntry.Substring(0, $match.Index + $match.Length)
+            if (-not $versionedDirs.ContainsKey($versionedPrefix)) {
+                $localDir = Join-Path -Path $OutPath -ChildPath $versionedPrefix
+                $versionedDirs[$versionedPrefix] = (Test-Path $localDir -PathType Container)
+            }
+        }
+    }
+
+    foreach ($dir in $versionedDirs.GetEnumerator()) {
+        if ($dir.Value) {
+            # This versioned directory already exists - exclude it from extraction
+            $pattern = $dir.Key + '*'
+            $excludeArgs += '--exclude'
+            $excludeArgs += $pattern
+            Say-Verbose "Excluding pre-existing versioned directory: $($dir.Key)"
+        }
+    }
+
+    # Handle non-versioned file override logic.
+    # If OverrideNonVersionedFiles is false, exclude non-versioned files that already exist.
+    if (-not $OverrideNonVersionedFiles) {
+        foreach ($entry in $tarListing) {
+            $normalizedEntry = $entry.Replace('\', '/')
+            # Skip directory entries (end with /)
+            if ($normalizedEntry.EndsWith('/')) { continue }
+            $match = [regex]::Match($normalizedEntry, $versionRegex)
+            if (-not $match.Success) {
+                # Non-versioned file - exclude if it already exists locally
+                $localPath = Join-Path -Path $OutPath -ChildPath $normalizedEntry
+                if (Test-Path $localPath) {
+                    $excludeArgs += '--exclude'
+                    $excludeArgs += $normalizedEntry
+                    Say-Verbose "Excluding pre-existing non-versioned file: $normalizedEntry"
+                }
+            }
+        }
+    }
+
+    try {
+        # Extract directly to install root, preserving hard links
+        $tarOutput = & tar -xzf $TarPath -C $OutPath @excludeArgs 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            $tarOutputText = ($tarOutput | Out-String).Trim()
+            if ([string]::IsNullOrWhiteSpace($tarOutputText)) {
+                throw "Tar extraction failed with exit code $LASTEXITCODE."
+            }
+            throw "Tar extraction failed with exit code $LASTEXITCODE. tar output: $tarOutputText"
+        }
+    }
+    catch {
+        Say-Error "Failed to extract tar package. Exception: $_"
+        throw
+    }
+}
+
+function DownloadFile($Source, [string]$OutPath) {
+    if ($Source -notlike "http*") {
+        #  Using System.IO.Path.GetFullPath to get the current directory
+        #    does not work in this context - $pwd gives the current directory
+        if (![System.IO.Path]::IsPathRooted($Source)) {
+            $Source = $(Join-Path -Path $pwd -ChildPath $Source)
+        }
+        $Source = Get-Absolute-Path $Source
+        Say "Copying file from $Source to $OutPath"
+        Copy-Item $Source $OutPath
+        return
+    }
+
+    $Stream = $null
+    
+    try {
+        $Response = GetHTTPResponse -Uri $Source
+        $Stream = $Response.Content.ReadAsStreamAsync().Result
+        $File = [System.IO.File]::Create($OutPath)
+        $Stream.CopyTo($File)
+        $File.Close()
+
+        ValidateRemoteLocalFileSizes -LocalFileOutPath $OutPath -SourceUri $Source
+    }
+    finally {
+        if ($null -ne $Stream) {
+            $Stream.Dispose()
+        }
+    }
+}
+
+function ValidateRemoteLocalFileSizes([string]$LocalFileOutPath, $SourceUri) {
+    try {
+        $remoteFileSize = Get-Remote-File-Size -zipUri $SourceUri
+        $fileSize = [long](Get-Item $LocalFileOutPath).Length
+        Say "Downloaded file $SourceUri size is $fileSize bytes."
+    
+        if ((![string]::IsNullOrEmpty($remoteFileSize)) -and !([string]::IsNullOrEmpty($fileSize)) ) {
+            if ($remoteFileSize -ne $fileSize) {
+                Say "The remote and local file sizes are not equal. Remote file size is $remoteFileSize bytes and local size is $fileSize bytes. The local package may be corrupted."
+            }
+            else {
+                Say "The remote and local file sizes are equal."
+            }   
+        }
+        else {
+            Say "Either downloaded or local package size can not be measured. One of them may be corrupted."
+        }
+    }
+    catch {
+        Say "Either downloaded or local package size can not be measured. One of them may be corrupted."
+    }
+}
+
+function SafeRemoveFile($Path) {
+    try {
+        if (Test-Path $Path) {
+            Remove-Item $Path
+            Say-Verbose "The temporary file `"$Path`" was removed."
+        }
+        else {
+            Say-Verbose "The temporary file `"$Path`" does not exist, therefore is not removed."
+        }
+    }
+    catch {
+        Say-Warning "Failed to remove the temporary file: `"$Path`", remove it manually."
+    }
+}
+
+function Prepend-Sdk-InstallRoot-To-Path([string]$InstallRoot) {
+    $BinPath = Get-Absolute-Path $(Join-Path -Path $InstallRoot -ChildPath "")
+    if (-Not $NoPath) {
+        $SuffixedBinPath = "$BinPath;"
+        if (-Not $env:path.Contains($SuffixedBinPath)) {
+            Say "Adding to current process PATH: `"$BinPath`". Note: This change will not be visible if PowerShell was run as a child process."
+            $env:path = $SuffixedBinPath + $env:path
+        }
+        else {
+            Say-Verbose "Current process PATH already contains `"$BinPath`""
+        }
+    }
+    else {
+        Say "Binaries of dotnet can be found in $BinPath"
+    }
+}
+
+function PrintDryRunOutput($Invocation, $DownloadLinks) {
+    Say "Payload URLs:"
+    
+    for ($linkIndex = 0; $linkIndex -lt $DownloadLinks.count; $linkIndex++) {
+        Say "URL #$linkIndex - $($DownloadLinks[$linkIndex].type): $($DownloadLinks[$linkIndex].downloadLink)"
+    }
+    $RepeatableCommand = ".\$ScriptName -Version `"$SpecificVersion`" -InstallDir `"$InstallRoot`" -Architecture `"$CLIArchitecture`""
+    if ($Runtime -eq "dotnet") {
+        $RepeatableCommand += " -Runtime `"dotnet`""
+    }
+    elseif ($Runtime -eq "aspnetcore") {
+        $RepeatableCommand += " -Runtime `"aspnetcore`""
+    }
+
+    foreach ($key in $Invocation.BoundParameters.Keys) {
+        if (-not (@("Architecture", "Channel", "DryRun", "InstallDir", "Runtime", "SharedRuntime", "Version", "Quality", "FeedCredential") -contains $key)) {
+            $RepeatableCommand += " -$key `"$($Invocation.BoundParameters[$key])`""
+        }
+    }
+    if ($Invocation.BoundParameters.Keys -contains "FeedCredential") {
+        $RepeatableCommand += " -FeedCredential `"<feedCredential>`""
+    }
+    Say "Repeatable invocation: $RepeatableCommand"
+    if ($SpecificVersion -ne $EffectiveVersion) {
+        Say "NOTE: Due to finding a version manifest with this runtime, it would actually install with version '$EffectiveVersion'"
+    }
+}
+
+function Get-AkaMSDownloadLink([string]$Channel, [string]$Quality, [bool]$Internal, [string]$Product, [string]$Architecture, [string]$FileExtension = ".zip") {
+    Say-Invocation $MyInvocation 
+
+    #quality is not supported for LTS or STS channel
+    if (![string]::IsNullOrEmpty($Quality) -and (@("LTS", "STS") -contains $Channel)) {
+        $Quality = ""
+        Say-Warning "Specifying quality for STS or LTS channel is not supported, the quality will be ignored."
+    }
+    Say-Verbose "Retrieving primary payload URL from aka.ms link for channel: '$Channel', quality: '$Quality' product: '$Product', os: 'win', architecture: '$Architecture'." 
+   
+    #construct aka.ms link
+    $akaMsLink = "https://aka.ms/dotnet"
+    if ($Internal) {
+        $akaMsLink += "/internal"
+    }
+    $akaMsLink += "/$Channel"
+    if (-not [string]::IsNullOrEmpty($Quality)) {
+        $akaMsLink += "/$Quality"
+    }
+    $akaMsLink += "/$Product-win-$Architecture$FileExtension"
+    Say-Verbose  "Constructed aka.ms link: '$akaMsLink'."
+    $akaMsDownloadLink = $null
+
+    for ($maxRedirections = 9; $maxRedirections -ge 0; $maxRedirections--) {
+        #get HTTP response
+        #do not pass credentials as a part of the $akaMsLink and do not apply credentials in the GetHTTPResponse function
+        #otherwise the redirect link would have credentials as well
+        #it would result in applying credentials twice to the resulting link and thus breaking it, and in echoing credentials to the output as a part of redirect link
+        $Response = GetHTTPResponse -Uri $akaMsLink -HeaderOnly $true -DisableRedirect $true -DisableFeedCredential $true
+        Say-Verbose "Received response:`n$Response"
+
+        if ([string]::IsNullOrEmpty($Response)) {
+            Say-Verbose "The link '$akaMsLink' is not valid: failed to get redirect location. The resource is not available."
+            return $null
+        }
+
+        #if HTTP code is 301 (Moved Permanently), the redirect link exists
+        if ($Response.StatusCode -eq 301) {
+            try {
+                $akaMsDownloadLink = $Response.Headers.GetValues("Location")[0]
+
+                if ([string]::IsNullOrEmpty($akaMsDownloadLink)) {
+                    Say-Verbose "The link '$akaMsLink' is not valid: server returned 301 (Moved Permanently), but the headers do not contain the redirect location."
+                    return $null
+                }
+
+                Say-Verbose "The redirect location retrieved: '$akaMsDownloadLink'."
+                # This may yet be a link to another redirection. Attempt to retrieve the page again.
+                $akaMsLink = $akaMsDownloadLink
+                continue
+            }
+            catch {
+                Say-Verbose "The link '$akaMsLink' is not valid: failed to get redirect location."
+                return $null
+            }
+        }
+        elseif ((($Response.StatusCode -lt 300) -or ($Response.StatusCode -ge 400)) -and (-not [string]::IsNullOrEmpty($akaMsDownloadLink))) {
+            # Redirections have ended.
+            return $akaMsDownloadLink
+        }
+
+        Say-Verbose "The link '$akaMsLink' is not valid: failed to retrieve the redirection location."
+        return $null
+    }
+
+    Say-Verbose "Aka.ms links have redirected more than the maximum allowed redirections. This may be caused by a cyclic redirection of aka.ms links."
+    return $null
+
+}
+
+function Get-AkaMsLink-And-Version([string] $NormalizedChannel, [string] $NormalizedQuality, [bool] $Internal, [string] $ProductName, [string] $Architecture) {
+
+    # When tar is available, try .tar.gz first via aka.ms, then fall back to .zip.
+    # This handles symbolic channels (STS/LTS) and numeric channels where tar.gz
+    # may not yet be available (e.g. pre-11.0 versions).
+    $extensionsToTry = @(".zip")
+    if ($script:TarAvailable) {
+        $extensionsToTry = @(".tar.gz", ".zip")
+    }
+
+    $AkaMsDownloadLink = $null
+    foreach ($ext in $extensionsToTry) {
+        $AkaMsDownloadLink = Get-AkaMSDownloadLink -Channel $NormalizedChannel -Quality $NormalizedQuality -Internal $Internal -Product $ProductName -Architecture $Architecture -FileExtension $ext
+        if (-not [string]::IsNullOrEmpty($AkaMsDownloadLink)) {
+            break
+        }
+        Say-Verbose "aka.ms link resolution with '$ext' extension failed, trying next format."
+    }
+   
+    if ([string]::IsNullOrEmpty($AkaMsDownloadLink)) {
+        if (-not [string]::IsNullOrEmpty($NormalizedQuality)) {
+            # if quality is specified - exit with error - there is no fallback approach
+            Say-Error "Failed to locate the latest version in the channel '$NormalizedChannel' with '$NormalizedQuality' quality for '$ProductName', os: 'win', architecture: '$Architecture'."
+            Say-Error "Refer to: https://aka.ms/dotnet-os-lifecycle for information on .NET Core support."
+            throw "aka.ms link resolution failure"
+        }
+        Say-Verbose "Falling back to latest.version file approach."
+        return ($null, $null, $null)
+    }
+    else {
+        Say-Verbose "Retrieved primary named payload URL from aka.ms link: '$AkaMsDownloadLink'."
+        Say-Verbose  "Downloading using legacy url will not be attempted."
+
+        #get version from the path
+        $pathParts = $AkaMsDownloadLink.Split('/')
+        if ($pathParts.Length -ge 2) { 
+            $SpecificVersion = $pathParts[$pathParts.Length - 2]
+            Say-Verbose "Version: '$SpecificVersion'."
+        }
+        else {
+            Say-Error "Failed to extract the version from download link '$AkaMsDownloadLink'."
+            return ($null, $null, $null)
+        }
+
+        #retrieve effective (product) version
+        $EffectiveVersion = Get-Product-Version -SpecificVersion $SpecificVersion -PackageDownloadLink $AkaMsDownloadLink
+        Say-Verbose "Product version: '$EffectiveVersion'."
+
+        return ($AkaMsDownloadLink, $SpecificVersion, $EffectiveVersion);
+    }
+}
+
+function Get-Feeds-To-Use() {
+    $feeds = @(
+        "https://builds.dotnet.microsoft.com/dotnet"
+        "https://ci.dot.net/public"
+    )
+
+    if (-not [string]::IsNullOrEmpty($AzureFeed)) {
+        $feeds = @($AzureFeed)
+    }
+
+    if (-not [string]::IsNullOrEmpty($UncachedFeed)) {
+            $feeds = @($UncachedFeed)
+    }
+
+    Write-Verbose "Initialized feeds: $feeds"
+
+    return $feeds
+}
+
+function Resolve-AssetName-And-RelativePath([string] $Runtime) {
+    
+    if ($Runtime -eq "dotnet") {
+        $assetName = ".NET Core Runtime"
+        $dotnetPackageRelativePath = "shared\Microsoft.NETCore.App"
+    }
+    elseif ($Runtime -eq "aspnetcore") {
+        $assetName = "ASP.NET Core Runtime"
+        $dotnetPackageRelativePath = "shared\Microsoft.AspNetCore.App"
+    }
+    elseif ($Runtime -eq "windowsdesktop") {
+        $assetName = ".NET Core Windows Desktop Runtime"
+        $dotnetPackageRelativePath = "shared\Microsoft.WindowsDesktop.App"
+    }
+    elseif (-not $Runtime) {
+        $assetName = ".NET Core SDK"
+        $dotnetPackageRelativePath = "sdk"
+    }
+    else {
+        throw "Invalid value for `$Runtime"
+    }
+
+    return ($assetName, $dotnetPackageRelativePath)
+}
+
+function Prepare-Install-Directory {
+    $diskSpaceWarning = "Failed to check the disk space. Installation will continue, but it may fail if you do not have enough disk space.";
+
+    if ($PSVersionTable.PSVersion.Major -lt 7) {
+        Say-Verbose $diskSpaceWarning
+        return
+    }
+
+    New-Item -ItemType Directory -Force -Path $InstallRoot | Out-Null
+
+    $installDrive = $((Get-Item $InstallRoot -Force).PSDrive.Name);
+    $diskInfo = $null
+    try {
+        $diskInfo = Get-PSDrive -Name $installDrive
+    }
+    catch {
+        Say-Warning $diskSpaceWarning
+    }
+
+    # The check is relevant for PS version >= 7, the result can be irrelevant for older versions. See https://github.com/PowerShell/PowerShell/issues/12442.
+    if ( ($null -ne $diskInfo) -and ($diskInfo.Free / 1MB -le 100)) {
+        throw "There is not enough disk space on drive ${installDrive}:"
+    }
+}
+
+if ($Help) {
+    Get-Help $PSCommandPath -Examples
+    exit
+}
+
+Say-Verbose "Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:"
+Say-Verbose "- The SDK needs to be installed without user interaction and without admin rights."
+Say-Verbose "- The SDK installation doesn't need to persist across multiple CI runs."
+Say-Verbose "To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.`r`n"
+
+if ($SharedRuntime -and (-not $Runtime)) {
+    $Runtime = "dotnet"
+}
+
+$OverrideNonVersionedFiles = !$SkipNonVersionedFiles
+
+Measure-Action "Product discovery" {
+    $script:CLIArchitecture = Get-CLIArchitecture-From-Architecture $Architecture
+    $script:NormalizedQuality = Get-NormalizedQuality $Quality
+    Say-Verbose "Normalized quality: '$NormalizedQuality'"
+    $script:NormalizedChannel = Get-NormalizedChannel $Channel
+    Say-Verbose "Normalized channel: '$NormalizedChannel'"
+    $script:NormalizedProduct = Get-NormalizedProduct $Runtime
+    Say-Verbose "Normalized product: '$NormalizedProduct'"
+    $script:FeedCredential = ValidateFeedCredential $FeedCredential
+    $script:TarAvailable = Test-TarAvailable
+    Say-Verbose "Tar available: '$TarAvailable'"
+}
+
+$InstallRoot = Resolve-Installation-Path $InstallDir
+if (-not (Test-User-Write-Access $InstallRoot)) {
+    Say-Error "The current user doesn't have write access to the installation root '$InstallRoot' to install .NET. Please try specifying a different installation directory using the -InstallDir parameter, or ensure the selected directory has the appropriate permissions."
+    throw
+}
+Say-Verbose "InstallRoot: $InstallRoot"
+$ScriptName = $MyInvocation.MyCommand.Name
+($assetName, $dotnetPackageRelativePath) = Resolve-AssetName-And-RelativePath -Runtime $Runtime
+
+$feeds = Get-Feeds-To-Use
+$DownloadLinks = @()
+
+if ($Version.ToLowerInvariant() -ne "latest" -and -not [string]::IsNullOrEmpty($Quality)) {
+    throw "Quality and Version options are not allowed to be specified simultaneously. See https:// learn.microsoft.com/dotnet/core/tools/dotnet-install-script#options for details."
+}
+
+# aka.ms links can only be used if the user did not request a specific version via the command line or a global.json file.
+if ([string]::IsNullOrEmpty($JSonFile) -and ($Version -eq "latest")) {
+    ($DownloadLink, $SpecificVersion, $EffectiveVersion) = Get-AkaMsLink-And-Version $NormalizedChannel $NormalizedQuality $Internal $NormalizedProduct $CLIArchitecture
+    
+    if ($null -ne $DownloadLink) {
+        $DownloadLinks += New-Object PSObject -Property @{downloadLink = "$DownloadLink"; specificVersion = "$SpecificVersion"; effectiveVersion = "$EffectiveVersion"; type = 'aka.ms' }
+        Say-Verbose "Generated aka.ms link $DownloadLink with version $EffectiveVersion"
+        
+        if (-Not $DryRun) {
+            Say-Verbose "Checking if the version $EffectiveVersion is already installed"
+            if (Is-Dotnet-Package-Installed -InstallRoot $InstallRoot -RelativePathToPackage $dotnetPackageRelativePath -SpecificVersion $EffectiveVersion) {
+                Say "$assetName with version '$EffectiveVersion' is already installed."
+                Prepend-Sdk-InstallRoot-To-Path -InstallRoot $InstallRoot
+                return
+            }
+        }
+    }
+}
+
+# Primary and legacy links cannot be used if a quality was specified.
+# If we already have an aka.ms link, no need to search the blob feeds.
+if ([string]::IsNullOrEmpty($NormalizedQuality) -and 0 -eq $DownloadLinks.count) {
+    foreach ($feed in $feeds) {
+        try {
+            $SpecificVersion = Get-Specific-Version-From-Version -AzureFeed $feed -Channel $Channel -Version $Version -JSonFile $JSonFile
+            $DownloadLink, $EffectiveVersion = Get-Download-Link -AzureFeed $feed -SpecificVersion $SpecificVersion -CLIArchitecture $CLIArchitecture
+            $LegacyDownloadLink = Get-LegacyDownload-Link -AzureFeed $feed -SpecificVersion $SpecificVersion -CLIArchitecture $CLIArchitecture
+            
+            $DownloadLinks += New-Object PSObject -Property @{downloadLink = "$DownloadLink"; specificVersion = "$SpecificVersion"; effectiveVersion = "$EffectiveVersion"; type = 'primary' }
+            Say-Verbose "Generated primary link $DownloadLink with version $EffectiveVersion"
+    
+            if (-not [string]::IsNullOrEmpty($LegacyDownloadLink)) {
+                $DownloadLinks += New-Object PSObject -Property @{downloadLink = "$LegacyDownloadLink"; specificVersion = "$SpecificVersion"; effectiveVersion = "$EffectiveVersion"; type = 'legacy' }
+                Say-Verbose "Generated legacy link $LegacyDownloadLink with version $EffectiveVersion"
+            }
+    
+            if (-Not $DryRun) {
+                Say-Verbose "Checking if the version $EffectiveVersion is already installed"
+                if (Is-Dotnet-Package-Installed -InstallRoot $InstallRoot -RelativePathToPackage $dotnetPackageRelativePath -SpecificVersion $EffectiveVersion) {
+                    Say "$assetName with version '$EffectiveVersion' is already installed."
+                    Prepend-Sdk-InstallRoot-To-Path -InstallRoot $InstallRoot
+                    return
+                }
+            }
+        }
+        catch {
+            Say-Verbose "Failed to acquire download links from feed $feed. Exception: $_"
+        }
+    }
+}
+
+if ($DownloadLinks.count -eq 0) {
+    throw "Failed to resolve the exact version number."
+}
+
+if ($DryRun) {
+    PrintDryRunOutput $MyInvocation $DownloadLinks
+    return
+}
+
+Measure-Action "Installation directory preparation" { Prepare-Install-Directory }
+
+Say-Verbose "Zip path: $ZipPath"
+
+$DownloadSucceeded = $false
+$DownloadedLink = $null
+$ErrorMessages = @()
+
+foreach ($link in $DownloadLinks) {
+    Say-Verbose "Downloading `"$($link.type)`" link $($link.downloadLink)"
+
+    try {
+        Measure-Action "Package download" { DownloadFile -Source $link.downloadLink -OutPath $ZipPath }
+        Say-Verbose "Download succeeded."
+        $DownloadSucceeded = $true
+        $DownloadedLink = $link
+        break
+    }
+    catch {
+        $StatusCode = $null
+        $ErrorMessage = $null
+
+        if ($PSItem.Exception.Data.Contains("StatusCode")) {
+            $StatusCode = $PSItem.Exception.Data["StatusCode"]
+        }
+    
+        if ($PSItem.Exception.Data.Contains("ErrorMessage")) {
+            $ErrorMessage = $PSItem.Exception.Data["ErrorMessage"]
+        }
+        else {
+            $ErrorMessage = $PSItem.Exception.Message
+        }
+
+        Say-Verbose "Download failed with status code $StatusCode. Error message: $ErrorMessage"
+        $ErrorMessages += "Downloading from `"$($link.type)`" link has failed with error:`nUri: $($link.downloadLink)`nStatusCode: $StatusCode`nError: $ErrorMessage"
+    }
+
+    # This link failed. Clean up before trying the next one.
+    SafeRemoveFile -Path $ZipPath
+}
+
+if (-not $DownloadSucceeded) {
+    foreach ($ErrorMessage in $ErrorMessages) {
+        Say-Error $ErrorMessages
+    }
+
+    throw "Could not find `"$assetName`" with version = $($DownloadLinks[0].effectiveVersion)`nRefer to: https://aka.ms/dotnet-os-lifecycle for information on .NET support"
+}
+
+Say "Extracting the archive."
+if ($DownloadedLink.downloadLink.EndsWith(".tar.gz")) {
+    Measure-Action "Package extraction" { Extract-Dotnet-Package-Tar -TarPath $ZipPath -OutPath $InstallRoot }
+}
+else {
+    Measure-Action "Package extraction" { Extract-Dotnet-Package -ZipPath $ZipPath -OutPath $InstallRoot }
+}
+
+#  Check if the SDK version is installed; if not, fail the installation.
+$isAssetInstalled = $false
+
+# if the version contains "RTM" or "servicing"; check if a 'release-type' SDK version is installed.
+if ($DownloadedLink.effectiveVersion -Match "rtm" -or $DownloadedLink.effectiveVersion -Match "servicing") {
+    $ReleaseVersion = $DownloadedLink.effectiveVersion.Split("-")[0]
+    Say-Verbose "Checking installation: version = $ReleaseVersion"
+    $isAssetInstalled = Is-Dotnet-Package-Installed -InstallRoot $InstallRoot -RelativePathToPackage $dotnetPackageRelativePath -SpecificVersion $ReleaseVersion
+}
+
+#  Check if the SDK version is installed.
+if (!$isAssetInstalled) {
+    Say-Verbose "Checking installation: version = $($DownloadedLink.effectiveVersion)"
+    $isAssetInstalled = Is-Dotnet-Package-Installed -InstallRoot $InstallRoot -RelativePathToPackage $dotnetPackageRelativePath -SpecificVersion $DownloadedLink.effectiveVersion
+}
+
+# Version verification failed. More likely something is wrong either with the downloaded content or with the verification algorithm.
+if (!$isAssetInstalled) {
+    Say-Error "Failed to verify the version of installed `"$assetName`".`nInstallation source: $($DownloadedLink.downloadLink).`nInstallation location: $InstallRoot.`nReport the bug at https://github.com/dotnet/install-scripts/issues."
+    throw "`"$assetName`" with version = $($DownloadedLink.effectiveVersion) failed to install with an unknown error."
+}
+
+if (-not $KeepZip) {
+    SafeRemoveFile -Path $ZipPath
+}
+
+Measure-Action "Setting up shell environment" { Prepend-Sdk-InstallRoot-To-Path -InstallRoot $InstallRoot }
+
+Say "Note that the script does not ensure your Windows version is supported during the installation."
+Say "To check the list of supported versions, go to https://learn.microsoft.com/dotnet/core/install/windows#supported-versions"
+Say "Installed version is $($DownloadedLink.effectiveVersion)"
+Say "Installation finished"
+
+# SIG # Begin signature block
+# MIIncQYJKoZIhvcNAQcCoIInYjCCJ14CAQExDzANBglghkgBZQMEAgEFADB5Bgor
+# BgEEAYI3AgEEoGswaTA0BgorBgEEAYI3AgEeMCYCAwEAAAQQH8w7YFlLCE63JNLG
+# KX7zUQIBAAIBAAIBAAIBAAIBADAxMA0GCWCGSAFlAwQCAQUABCDbixcRHZx4cmqV
+# 58QdPY+XiwQw34JjAyv8LsJIGTKYs6CCDMkwggYEMIID7KADAgECAhMzAAACHPrN
+# xZvoL37EAAAAAAIcMA0GCSqGSIb3DQEBCwUAMFcxCzAJBgNVBAYTAlVTMR4wHAYD
+# VQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xKDAmBgNVBAMTH01pY3Jvc29mdCBD
+# b2RlIFNpZ25pbmcgUENBIDIwMjQwHhcNMjYwNDE2MTg1OTQxWhcNMjcwNDE1MTg1
+# OTQxWjB0MQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UE
+# BxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMR4wHAYD
+# VQQDExVNaWNyb3NvZnQgQ29ycG9yYXRpb24wggEiMA0GCSqGSIb3DQEBAQUAA4IB
+# DwAwggEKAoIBAQDVsZfgOKmM31HPfoWOoNEiw0SlCiIxUMC0I9NMWbucKOw/e9lP
+# oAoehQVu6SG65V4EPzrYsnBnFPNoi4/HoOdjhz1qkrEt4I6tEcxXU6oOeY9zGveC
+# /3iBeuhLYxM3M/PkcUoebF+Nednm8OkdSPoDu8imViHPQq/8CQUu0WRR4rE+dMRf
+# rpVqfmNi2qWCX94T4MsepijGVkwE//tJg0ryAiYdHT34LSnlG/RSBZmQRGWZ5g8j
+# qnKjRParSqMft1gvjuUTVgtWNZfgcLFSK5Wa0myrq8OPcgTGGsRgun+tnSS+IxDT
+# xVsAPH1OzvPjwomguByhUe/OcvUN0D5Wmp7xAgMBAAGjggGqMIIBpjAOBgNVHQ8B
+# Af8EBAMCB4AwHwYDVR0lBBgwFgYKKwYBBAGCN0wIAQYIKwYBBQUHAwMwHQYDVR0O
+# BBYEFNoH7a2YDjOSwpkp6DHcmUS7J+0yMFQGA1UdEQRNMEukSTBHMS0wKwYDVQQL
+# EyRNaWNyb3NvZnQgSXJlbGFuZCBPcGVyYXRpb25zIExpbWl0ZWQxFjAUBgNVBAUT
+# DTIzMDAxMis1MDc1NjkwHwYDVR0jBBgwFoAUf1k/VCHarU/vBeXmo9ctBpQSCDEw
+# YAYDVR0fBFkwVzBVoFOgUYZPaHR0cDovL3d3dy5taWNyb3NvZnQuY29tL3BraW9w
+# cy9jcmwvTWljcm9zb2Z0JTIwQ29kZSUyMFNpZ25pbmclMjBQQ0ElMjAyMDI0LmNy
+# bDBtBggrBgEFBQcBAQRhMF8wXQYIKwYBBQUHMAKGUWh0dHA6Ly93d3cubWljcm9z
+# b2Z0LmNvbS9wa2lvcHMvY2VydHMvTWljcm9zb2Z0JTIwQ29kZSUyMFNpZ25pbmcl
+# MjBQQ0ElMjAyMDI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IC
+# AQAUnEqhaRXe0T3hIJjvdQErEkrA/7bByjn6t5IArODkkRjzkYwtKMc2yYj2quaN
+# rLutWw2YZcngKPy1b71YyDJQTy4NDRwaSh9Tw5thrk3NmcPrAHia5vtcBJ1CgtKK
+# 7mQbIcQ22d/N3813ayCDDFewu1+jsZmX+r/aTEqaOM4TVxVtRSkuCy8nAXKuChOK
+# Li/zA4XuH8iEYqIsj2YoNaeSxVmeGiERXpKdo3dDmYi0kO5w2D8VS4c3+9h6gElY
+# BaAAg/dYErBg27qT3vv0zRDJhJufvCNylA8S7/+8H5E/PV5cng6na9VV/w9OV3qu
+# uND6zdGa2EX38Glp50F9AIQk3p2xXmcvorDeM4XJ7UlWYBi6g80J1SSOQnInCYFE
+# msfUNn3+1AaTJKSJL83quKArTac2pKhu0Yzzzrzo6HrsRiQKzpnRBb1/dMa6P3hz
+# 75XbMRBctNsFhZC07WCmjExdLg2eHW5uV0TY8D5+6wozJf7vF3+WHkYPO85Z+BC6
+# U4FkNbYNycZ9cE4j1tXRdyDCfml6c0HWPHjNVDObrv9lKt3qUqFpX38VCqVCyNOO
+# 1UcXfQiVjJw32U2WUKZjt/neJKHEBsm9kFsLuWzkQ53+qcaSaytmsCnk2gOglrlD
+# 5d3kKyvvAw+rzm0lT8K38P6PLxfZQHhu4W8dV7Av8N2ZmDCCBr0wggSloAMCAQIC
+# EzMAAAA5O7Y3Gb8GHWcAAAAAADkwDQYJKoZIhvcNAQEMBQAwgYgxCzAJBgNVBAYT
+# AlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYD
+# VQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xMjAwBgNVBAMTKU1pY3Jvc29mdCBS
+# b290IENlcnRpZmljYXRlIEF1dGhvcml0eSAyMDExMB4XDTI0MDgwODIwNTQxOFoX
+# DTM2MDMyMjIyMTMwNFowVzELMAkGA1UEBhMCVVMxHjAcBgNVBAoTFU1pY3Jvc29m
+# dCBDb3Jwb3JhdGlvbjEoMCYGA1UEAxMfTWljcm9zb2Z0IENvZGUgU2lnbmluZyBQ
+# Q0EgMjAyNDCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANgBnB7jOMeq
+# lRYHNa265v4IY9fH8TKhemHfPINe1gpLaV3dhg324WwH06LcHbpnsBukCDNitryo
+# 0dtS/EW6I/yEL/bLSY8hKpbfQuWusBPr9qazYcDxCW/qnjb5JsI1s8bNOg3bVATv
+# QVL4tcf03aTycsz8QeCdM0l/yHRObJ9QqazM1r6VPEOJ7LL+uEEb73w6QCuhs89a
+# 1uv1zerOYMnsneRRwCbpyW11IcggU0cRKDDq1pjVJzIbIF6+oiXXbReOsgeI8zu1
+# FyQfK0fVkaya8SmVHQ/tOf23mZ4W9k0Ri22QW9p3UgSC5OUDktKxxcCmGL6tXLfO
+# GSWHIIV4YrTJTT6PNty5REojHJuZHArkF9VnHTERWoTjAzfI3kP+5b4alUdhgAZ7
+# ttOu1bVnXfHaqPYl2rPs20ji03LOVWsh/radgE17es5hL+t6lV0eVHrVhsssROWJ
+# uz2MXMCt7iw7lFPG9LXKGjsmonn2gotGdHIuEg5JnJMJVmixd5LRlkmgYRZKzhxS
+# CwyoGIq0PhaA7Y+VPct5pCHkijcIIDm0nlkK+0KyepolcqGm0T/GYQRMhHJlGOOm
+# VQop36wUVUYklUy++vDWeEgEo4s7hxN6mIbf2MSIQ/iIfMZgJxC69oukMUXCrOC3
+# SkE/xIkgpfl22MM1itkZ35nNXkMolU1lAgMBAAGjggFOMIIBSjAOBgNVHQ8BAf8E
+# BAMCAYYwEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFH9ZP1Qh2q1P7wXl5qPX
+# LQaUEggxMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMA8GA1UdEwEB/wQFMAMB
+# Af8wHwYDVR0jBBgwFoAUci06AjGQQ7kUBU7h6qfHMdEjiTQwWgYDVR0fBFMwUTBP
+# oE2gS4ZJaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraS9jcmwvcHJvZHVjdHMv
+# TWljUm9vQ2VyQXV0MjAxMV8yMDExXzAzXzIyLmNybDBeBggrBgEFBQcBAQRSMFAw
+# TgYIKwYBBQUHMAKGQmh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMv
+# TWljUm9vQ2VyQXV0MjAxMV8yMDExXzAzXzIyLmNydDANBgkqhkiG9w0BAQwFAAOC
+# AgEAFJQfOChP7onn6fLIMKrSlN1WYKwDFgAddymOUO3FrM8d7B/W/iQ6DxXsDn7D
+# 5W4wMwYeLystcEqfkjz4NURRgazyMu5yRzQh4LqjA4tStTcJh1opExo7nn5PuPBY
+# nbu0+THSuVHTe0VTTPVhily/piFrDo3axQ9P4C+Ol5yet+2gTfekICS5xS+cYfSI
+# vgn0JksVBVMYVI5QFu/qhnLhsEFEUzG8fvv0hjgkO+lkpV9ty6GkN4vdnd7ya6Q6
+# aR9y34aiM1qmxaxBi6OUnyNl6fkuun/diTFnYDLTppOkr/mg5WSfCiDVMNCxtj4w
+# PKC5OmHm1DQIt/MNokbbH3UGsFP1QbzsLocuSqLCvH09Io3fDPTmscR9Y75G4qX7
+# RTX8AdBPo0I6OEojf39zuFZt0qOHm65YWQE69cZM2ueE1MB05dNNgHK9gTE7zKvK
+# /fg8B2qjW88MT/WF5V5uvZGtqa9FSL2RazArA+rDPuf6JGYz4HpgMZHB4S6szWSK
+# YBv0VisCzfxgeU+dquXW9bd0auYlOB58DPcOYKdc3Se94g+xL4pcEhbB54JOgAkw
+# YTu/9dLeH2pDqeJZAABVDWRQCaXfO5LgyKwKCLYXpigrZYCjUSBcr+Ve8PFWMhVT
+# Ql0v4q8J/AUmQN5W4n101cY2L4A7GTQG1h32HHAvfQESWP0xghn+MIIZ+gIBATBu
+# MFcxCzAJBgNVBAYTAlVTMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24x
+# KDAmBgNVBAMTH01pY3Jvc29mdCBDb2RlIFNpZ25pbmcgUENBIDIwMjQCEzMAAAIc
+# +s3Fm+gvfsQAAAAAAhwwDQYJYIZIAWUDBAIBBQCgga4wGQYJKoZIhvcNAQkDMQwG
+# CisGAQQBgjcCAQQwHAYKKwYBBAGCNwIBCzEOMAwGCisGAQQBgjcCARUwLwYJKoZI
+# hvcNAQkEMSIEIPGYOwqjbYcPpGhrXbJoGwiSMzNy0DFg1wPuMKjzUFU3MEIGCisG
+# AQQBgjcCAQwxNDAyoBSAEgBNAGkAYwByAG8AcwBvAGYAdKEagBhodHRwOi8vd3d3
+# Lm1pY3Jvc29mdC5jb20wDQYJKoZIhvcNAQEBBQAEggEATEc7CdUQlF9ad/L6EImG
+# GP+g++vMy0R/Hg4c+MlO/1U5MYfOdh4p0OSk0R3D9KhIvGy0pmPFjbCovy8OT1o0
+# /SmlfLvdZi71NTu7USS9IBaGa34XbhtETx7bqyEuFVyJi3Q6kem+/FX4X9Yy1uKa
+# raasZebqi0W5Bwmm/l2W2vJoRejOf73LY/JVDJDoqC6Euy0ygFMRcXKuy0JapfNW
+# uzhOnMSTeEhxSnJulIJT9WJ27C0C3xCs15Zxog1pTCIyrUdZ+1wztImKRG6ckOMs
+# stSyISi+BDDDZlEIrqW28uhS3y1NamvJ8ParfgUUMWE6IVMfXyU3UNX9CffZlZUu
+# G6GCF7AwghesBgorBgEEAYI3AwMBMYIXnDCCF5gGCSqGSIb3DQEHAqCCF4kwgheF
+# AgEDMQ8wDQYJYIZIAWUDBAIBBQAwggFaBgsqhkiG9w0BCRABBKCCAUkEggFFMIIB
+# QQIBAQYKKwYBBAGEWQoDATAxMA0GCWCGSAFlAwQCAQUABCAKISNs7txQuaBSV3EX
+# ZialoNXK4+PNZXnxI6CUNBDKJwIGajVNcfmeGBMyMDI2MDcxOTAxMTk1MS40NTVa
+# MASAAgH0oIHZpIHWMIHTMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3Rv
+# bjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0
+# aW9uMS0wKwYDVQQLEyRNaWNyb3NvZnQgSXJlbGFuZCBPcGVyYXRpb25zIExpbWl0
+# ZWQxJzAlBgNVBAsTHm5TaGllbGQgVFNTIEVTTjo0MDFBLTA1RTAtRDk0NzElMCMG
+# A1UEAxMcTWljcm9zb2Z0IFRpbWUtU3RhbXAgU2VydmljZaCCEf4wggcoMIIFEKAD
+# AgECAhMzAAACGV6y2FR19LGNAAEAAAIZMA0GCSqGSIb3DQEBCwUAMHwxCzAJBgNV
+# BAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4w
+# HAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xJjAkBgNVBAMTHU1pY3Jvc29m
+# dCBUaW1lLVN0YW1wIFBDQSAyMDEwMB4XDTI1MDgxNDE4NDgyNloXDTI2MTExMzE4
+# NDgyNlowgdMxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYD
+# VQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xLTAr
+# BgNVBAsTJE1pY3Jvc29mdCBJcmVsYW5kIE9wZXJhdGlvbnMgTGltaXRlZDEnMCUG
+# A1UECxMeblNoaWVsZCBUU1MgRVNOOjQwMUEtMDVFMC1EOTQ3MSUwIwYDVQQDExxN
+# aWNyb3NvZnQgVGltZS1TdGFtcCBTZXJ2aWNlMIICIjANBgkqhkiG9w0BAQEFAAOC
+# Ag8AMIICCgKCAgEApqFIyUkzIyxpL3Q03WmLuy4G9YIUScznhKr+cHOT+/u7Parx
+# I96gxxb1WrWuAxB8qjGLfsbImx8V3ouK1nUcf+R/nsnXas5/iTgV/Tl3QTRGT0De
+# uXBNbpHqc+wC1NiTyA76gLnirvSBEoBzlrpNQFEnuwdbPLCLpTS3KWSCu5J02b+R
+# FWR/kcFzVxnhoE3gIaeURtrGKGBZGKLBXvqggkDENtKkvtvRT32xLvAvL/RpReu5
+# z18ZojCs72ZSoa74Dy8YbaWsDm3OZOpJRZxZsPKCHZ6xNqgFKf0xNHj0t9v0Q3W+
+# 2z5gAVaasJJCvR52Sl0XJ2AOf3l0LSetXgUA5gD5IQ1RvEslTmNnSouTrGID3D1n
+# jY7mBu0puiIdPK2jK/1Weef2+YR4cQpWQkeBZmXidh9AuWdlwxKQL15LJ6K2dw8y
+# /t/PBhmLyt6QAf0CepWRdgZnMytVAUuWHwlZRV9JLY7aX8D55eL9+cOLpX3bGNOm
+# N24UpIW8qtZaqXaesFvIOW23JNLhaaQVvObr1eu7GE/5Mn43e+/DbtdYl/bLP2IQ
+# 1xYEJdSbcUkDFfW3KlZEh+nBKDtaRnNRkbgIgxIbKdT38OKQwZ/aA4uSsiAg6nEP
+# iWBHGuytIo5wU75M5VdjhEqqTHfXYu8BJi6GTzvWT+9ekfMXezqCkksxaG8CAwEA
+# AaOCAUkwggFFMB0GA1UdDgQWBBSAaOo5HWatNzqZn1IF1fcD6nr3ITAfBgNVHSME
+# GDAWgBSfpxVdAF5iXYP05dJlpxtTNRnpcjBfBgNVHR8EWDBWMFSgUqBQhk5odHRw
+# Oi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNyb3NvZnQlMjBUaW1l
+# LVN0YW1wJTIwUENBJTIwMjAxMCgxKS5jcmwwbAYIKwYBBQUHAQEEYDBeMFwGCCsG
+# AQUFBzAChlBodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01p
+# Y3Jvc29mdCUyMFRpbWUtU3RhbXAlMjBQQ0ElMjAyMDEwKDEpLmNydDAMBgNVHRMB
+# Af8EAjAAMBYGA1UdJQEB/wQMMAoGCCsGAQUFBwMIMA4GA1UdDwEB/wQEAwIHgDAN
+# BgkqhkiG9w0BAQsFAAOCAgEAXxzVZLLXBFfoCCCTiY7MHXdb7civJSTfrHYJC5Ok
+# 2NN75NpzTMT9V2TcIQjfQ3AFUbh1NBAYtMUuwxC6D4ceEXG5lXAnbvkC9YjeLVDR
+# yImXYYmft7z+Qpl9t3C/8a0tiqnOz8Ue8/DYLtMTgvWMnsqLNjILDaImOfnHI36T
+# LCjGFe8RYLXGdCUdOLlfAdMGePxSTA3TAAOc+GQbmPWjrguLWbxvnl3NVjRvrBZV
+# kxFMoVZH0f7qGwDOShjpnv5nYnQ48ufL0uBz52RbPGdX4Fv9+UGOrBprmcHzmIut
+# FtJec2Y4kujNtTK2wBGgWscEOVhFiaVdje8VLJ7MVNKE5TmsuGM3jTLr1nuR5AFG
+# s3UKkP7g3cQD4cHK7XdLiTm7e606QJ+WqeQsADYE9dvU9wIUbI9Dl4UcIErFw+FH
+# aWSTrkfJ4SvLmhKnl5khhpJ1sF3z6e1BxepUliXHqzRLiHWihWIWESF8IHElF3PO
+# xbP4VJqHBiYvaXMV0SyRgwoD6zXddbUnX9WR6JL2BlqAjjHxINwelsp/VhxAWThz
+# uMA58LxvE/VAzjfFF4Wm7a1ZALmJVw3oL/s/uxo1Op4tcT+hfZ9uN1htC1JN4DuR
+# qFfLttjuoAmUQobO5zUFRzvCn8Ck/hiO+bzR15sqkjlxLMyMjpkc/ef4SUUikD46
+# 8vUwggdxMIIFWaADAgECAhMzAAAAFcXna54Cm0mZAAAAAAAVMA0GCSqGSIb3DQEB
+# CwUAMIGIMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UE
+# BxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMTIwMAYD
+# VQQDEylNaWNyb3NvZnQgUm9vdCBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkgMjAxMDAe
+# Fw0yMTA5MzAxODIyMjVaFw0zMDA5MzAxODMyMjVaMHwxCzAJBgNVBAYTAlVTMRMw
+# EQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVN
+# aWNyb3NvZnQgQ29ycG9yYXRpb24xJjAkBgNVBAMTHU1pY3Jvc29mdCBUaW1lLVN0
+# YW1wIFBDQSAyMDEwMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA5OGm
+# TOe0ciELeaLL1yR5vQ7VgtP97pwHB9KpbE51yMo1V/YBf2xK4OK9uT4XYDP/XE/H
+# ZveVU3Fa4n5KWv64NmeFRiMMtY0Tz3cywBAY6GB9alKDRLemjkZrBxTzxXb1hlDc
+# wUTIcVxRMTegCjhuje3XD9gmU3w5YQJ6xKr9cmmvHaus9ja+NSZk2pg7uhp7M62A
+# W36MEBydUv626GIl3GoPz130/o5Tz9bshVZN7928jaTjkY+yOSxRnOlwaQ3KNi1w
+# jjHINSi947SHJMPgyY9+tVSP3PoFVZhtaDuaRr3tpK56KTesy+uDRedGbsoy1cCG
+# MFxPLOJiss254o2I5JasAUq7vnGpF1tnYN74kpEeHT39IM9zfUGaRnXNxF803RKJ
+# 1v2lIH1+/NmeRd+2ci/bfV+AutuqfjbsNkz2K26oElHovwUDo9Fzpk03dJQcNIIP
+# 8BDyt0cY7afomXw/TNuvXsLz1dhzPUNOwTM5TI4CvEJoLhDqhFFG4tG9ahhaYQFz
+# ymeiXtcodgLiMxhy16cg8ML6EgrXY28MyTZki1ugpoMhXV8wdJGUlNi5UPkLiWHz
+# NgY1GIRH29wb0f2y1BzFa/ZcUlFdEtsluq9QBXpsxREdcu+N+VLEhReTwDwV2xo3
+# xwgVGD94q0W29R6HXtqPnhZyacaue7e3PmriLq0CAwEAAaOCAd0wggHZMBIGCSsG
+# AQQBgjcVAQQFAgMBAAEwIwYJKwYBBAGCNxUCBBYEFCqnUv5kxJq+gpE8RjUpzxD/
+# LwTuMB0GA1UdDgQWBBSfpxVdAF5iXYP05dJlpxtTNRnpcjBcBgNVHSAEVTBTMFEG
+# DCsGAQQBgjdMg30BATBBMD8GCCsGAQUFBwIBFjNodHRwOi8vd3d3Lm1pY3Jvc29m
+# dC5jb20vcGtpb3BzL0RvY3MvUmVwb3NpdG9yeS5odG0wEwYDVR0lBAwwCgYIKwYB
+# BQUHAwgwGQYJKwYBBAGCNxQCBAweCgBTAHUAYgBDAEEwCwYDVR0PBAQDAgGGMA8G
+# A1UdEwEB/wQFMAMBAf8wHwYDVR0jBBgwFoAU1fZWy4/oolxiaNE9lJBb186aGMQw
+# VgYDVR0fBE8wTTBLoEmgR4ZFaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraS9j
+# cmwvcHJvZHVjdHMvTWljUm9vQ2VyQXV0XzIwMTAtMDYtMjMuY3JsMFoGCCsGAQUF
+# BwEBBE4wTDBKBggrBgEFBQcwAoY+aHR0cDovL3d3dy5taWNyb3NvZnQuY29tL3Br
+# aS9jZXJ0cy9NaWNSb29DZXJBdXRfMjAxMC0wNi0yMy5jcnQwDQYJKoZIhvcNAQEL
+# BQADggIBAJ1VffwqreEsH2cBMSRb4Z5yS/ypb+pcFLY+TkdkeLEGk5c9MTO1OdfC
+# cTY/2mRsfNB1OW27DzHkwo/7bNGhlBgi7ulmZzpTTd2YurYeeNg2LpypglYAA7AF
+# vonoaeC6Ce5732pvvinLbtg/SHUB2RjebYIM9W0jVOR4U3UkV7ndn/OOPcbzaN9l
+# 9qRWqveVtihVJ9AkvUCgvxm2EhIRXT0n4ECWOKz3+SmJw7wXsFSFQrP8DJ6LGYnn
+# 8AtqgcKBGUIZUnWKNsIdw2FzLixre24/LAl4FOmRsqlb30mjdAy87JGA0j3mSj5m
+# O0+7hvoyGtmW9I/2kQH2zsZ0/fZMcm8Qq3UwxTSwethQ/gpY3UA8x1RtnWN0SCyx
+# TkctwRQEcb9k+SS+c23Kjgm9swFXSVRk2XPXfx5bRAGOWhmRaw2fpCjcZxkoJLo4
+# S5pu+yFUa2pFEUep8beuyOiJXk+d0tBMdrVXVAmxaQFEfnyhYWxz/gq77EFmPWn9
+# y8FBSX5+k77L+DvktxW/tM4+pTFRhLy/AsGConsXHRWJjXD+57XQKBqJC4822rpM
+# +Zv/Cuk0+CQ1ZyvgDbjmjJnW4SLq8CdCPSWU5nR0W2rRnj7tfqAxM328y+l7vzhw
+# RNGQ8cirOoo6CGJ/2XBjU02N7oJtpQUQwXEGahC0HVUzWLOhcGbyoYIDWTCCAkEC
+# AQEwggEBoYHZpIHWMIHTMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3Rv
+# bjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0
+# aW9uMS0wKwYDVQQLEyRNaWNyb3NvZnQgSXJlbGFuZCBPcGVyYXRpb25zIExpbWl0
+# ZWQxJzAlBgNVBAsTHm5TaGllbGQgVFNTIEVTTjo0MDFBLTA1RTAtRDk0NzElMCMG
+# A1UEAxMcTWljcm9zb2Z0IFRpbWUtU3RhbXAgU2VydmljZaIjCgEBMAcGBSsOAwIa
+# AxUAMXYp/Wqqdyb0enigrLfxl0InAz6ggYMwgYCkfjB8MQswCQYDVQQGEwJVUzET
+# MBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMV
+# TWljcm9zb2Z0IENvcnBvcmF0aW9uMSYwJAYDVQQDEx1NaWNyb3NvZnQgVGltZS1T
+# dGFtcCBQQ0EgMjAxMDANBgkqhkiG9w0BAQsFAAIFAO4FXKYwIhgPMjAyNjA3MTgw
+# MjAwMDZaGA8yMDI2MDcxOTAyMDAwNlowdzA9BgorBgEEAYRZCgQBMS8wLTAKAgUA
+# 7gVcpgIBADAKAgEAAgIYywIB/zAHAgEAAgITSDAKAgUA7gauJgIBADA2BgorBgEE
+# AYRZCgQCMSgwJjAMBgorBgEEAYRZCgMCoAowCAIBAAIDB6EgoQowCAIBAAIDAYag
+# MA0GCSqGSIb3DQEBCwUAA4IBAQBq2r0gOT1OxJNWazOFyx2xCpcFbnegtTJkQ4PQ
+# VcbdTaxlE7ksYBeZ0zXLWiv/fSnhonUmp9ORGV6+2phlj6xeV4AyH4dVsmyRBiLN
+# +Fb7Q5qNxhG3ciablIePFBPSFxOxJ33x6wjJF9CLx7iuhmaykYlp5jhWQ3OQerd2
+# FB5vO417JsgGhZscrvZeeamXMWU6LvuPSX02oWth8FbfnIuty1OAtQh9iQwmllq4
+# T+dLJJSkC9Mh0gqKo+v5EBAIQ1fS5TsvfMW73Pt3lydMrZjRhdnTsQ4nge+iE8CN
+# XrKtIO0esovriWQVcDVYcu9DM/2P1UovTKoZ44pcxDz1zk4VMYIEDTCCBAkCAQEw
+# gZMwfDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcT
+# B1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEmMCQGA1UE
+# AxMdTWljcm9zb2Z0IFRpbWUtU3RhbXAgUENBIDIwMTACEzMAAAIZXrLYVHX0sY0A
+# AQAAAhkwDQYJYIZIAWUDBAIBBQCgggFKMBoGCSqGSIb3DQEJAzENBgsqhkiG9w0B
+# CRABBDAvBgkqhkiG9w0BCQQxIgQg1hCY9TskS/ocjoNgKVJVguEsAjqzxBlDPM+r
+# Bb91Lt8wgfoGCyqGSIb3DQEJEAIvMYHqMIHnMIHkMIG9BCDckX633E1y1EF32V18
+# zQcrsgjzI9+3Le7mlvk2OebthjCBmDCBgKR+MHwxCzAJBgNVBAYTAlVTMRMwEQYD
+# VQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNy
+# b3NvZnQgQ29ycG9yYXRpb24xJjAkBgNVBAMTHU1pY3Jvc29mdCBUaW1lLVN0YW1w
+# IFBDQSAyMDEwAhMzAAACGV6y2FR19LGNAAEAAAIZMCIEIDjz74g3CBfNc6GVJRjf
+# Y0YVIg76oCasifagFFulpBDbMA0GCSqGSIb3DQEBCwUABIICADak0YxE5whyHvYr
+# Zukn9brxBTp9erdA6poINujmoiK5ZrTv6SZYaJbSI0HnDxbxp9QchY3BwpI19ix5
+# +excveLH8i0oQWql3XyZcBDcwBi9sfFDv+yuJfd1CE27X8YxGy5OJeKCK9QoQiXs
+# b0MgT35WaxPxvRwcUArXf8qwkP+CO4EkL9x+ZCznyvutSebHKS5fRRPgVreJKRg2
+# vNh4J2lujjEIsOduZs8o5U7woRCBgN/v6lDl9x35WHgoHSzxSwQz7HZea/gcbXa6
+# GRezjA7bCzS1H99feDX3KiTi1kIxtKilQOVzOO9XqrTYoZGak7NeNW12IqbmeYHF
+# ZVW8XkBg5U8BdPpS/3/wD7Y8K1429YSIrJLdccR16TCwlItiqbnFrPt1+qPUH64K
+# okrklXX5tYZMe9cXKCC6GlP8oSw1mBf3i85h7YkQf7MgLMbhuBKPBndY7PYfeXNY
+# zjiH4lwKswYlJHqagmw2xYvT00Ekchjo9k6HGaUK1gzCK/ISGOiNb1pr6xf5hK6K
+# TL9zvNOvRxOr6L/fBLjzRFCy4TiBmOAn6uq50hl/7H7hwuoxIXVHcPqZbgRfng7z
+# PXEyYpUtVfNMlrFfD0u6mXTp9Ez+1W0hs55SVN4CuwKAO9g1nVBc5i+7KwEpYVfU
+# kJuzixuLkM8/Hhm7X6wRAwAqpA7P
+# SIG # End signature block

--- a/scripts/dotnet-install.sh
+++ b/scripts/dotnet-install.sh
@@ -1,0 +1,1887 @@
+#!/usr/bin/env bash
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+# Stop script on NZEC
+set -e
+# Stop script if unbound variable found (use ${var:-} if intentional)
+set -u
+# By default cmd1 | cmd2 returns exit code of cmd2 regardless of cmd1 success
+# This is causing it to fail
+set -o pipefail
+
+# Use in the the functions: eval $invocation
+invocation='say_verbose "Calling: ${yellow:-}${FUNCNAME[0]} ${green:-}$*${normal:-}"'
+
+# standard output may be used as a return value in the functions
+# we need a way to write text on the screen in the functions so that
+# it won't interfere with the return value.
+# Exposing stream 3 as a pipe to standard output of the script itself
+exec 3>&1
+
+# Setup some colors to use. These need to work in fairly limited shells, like the Ubuntu Docker container where there are only 8 colors.
+# See if stdout is a terminal
+if [ -t 1 ] && command -v tput > /dev/null; then
+    # see if it supports colors
+    ncolors=$(tput colors || echo 0)
+    if [ -n "$ncolors" ] && [ $ncolors -ge 8 ]; then
+        bold="$(tput bold       || echo)"
+        normal="$(tput sgr0     || echo)"
+        black="$(tput setaf 0   || echo)"
+        red="$(tput setaf 1     || echo)"
+        green="$(tput setaf 2   || echo)"
+        yellow="$(tput setaf 3  || echo)"
+        blue="$(tput setaf 4    || echo)"
+        magenta="$(tput setaf 5 || echo)"
+        cyan="$(tput setaf 6    || echo)"
+        white="$(tput setaf 7   || echo)"
+    fi
+fi
+
+say_warning() {
+    printf "%b\n" "${yellow:-}dotnet_install: Warning: $1${normal:-}" >&3
+}
+
+say_err() {
+    printf "%b\n" "${red:-}dotnet_install: Error: $1${normal:-}" >&2
+}
+
+say() {
+    # using stream 3 (defined in the beginning) to not interfere with stdout of functions
+    # which may be used as return value
+    printf "%b\n" "${cyan:-}dotnet-install:${normal:-} $1" >&3
+}
+
+say_verbose() {
+    if [ "$verbose" = true ]; then
+        say "$1"
+    fi
+}
+
+# This platform list is finite - if the SDK/Runtime has supported Linux distribution-specific assets,
+#   then and only then should the Linux distribution appear in this list.
+# Adding a Linux distribution to this list does not imply distribution-specific support.
+get_legacy_os_name_from_platform() {
+    eval $invocation
+
+    platform="$1"
+    case "$platform" in
+        "centos.7")
+            echo "centos"
+            return 0
+            ;;
+        "debian.8")
+            echo "debian"
+            return 0
+            ;;
+        "debian.9")
+            echo "debian.9"
+            return 0
+            ;;
+        "fedora.23")
+            echo "fedora.23"
+            return 0
+            ;;
+        "fedora.24")
+            echo "fedora.24"
+            return 0
+            ;;
+        "fedora.27")
+            echo "fedora.27"
+            return 0
+            ;;
+        "fedora.28")
+            echo "fedora.28"
+            return 0
+            ;;
+        "opensuse.13.2")
+            echo "opensuse.13.2"
+            return 0
+            ;;
+        "opensuse.42.1")
+            echo "opensuse.42.1"
+            return 0
+            ;;
+        "opensuse.42.3")
+            echo "opensuse.42.3"
+            return 0
+            ;;
+        "rhel.7"*)
+            echo "rhel"
+            return 0
+            ;;
+        "ubuntu.14.04")
+            echo "ubuntu"
+            return 0
+            ;;
+        "ubuntu.16.04")
+            echo "ubuntu.16.04"
+            return 0
+            ;;
+        "ubuntu.16.10")
+            echo "ubuntu.16.10"
+            return 0
+            ;;
+        "ubuntu.18.04")
+            echo "ubuntu.18.04"
+            return 0
+            ;;
+        "alpine.3.4.3")
+            echo "alpine"
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+get_legacy_os_name() {
+    eval $invocation
+
+    local uname=$(uname)
+    if [ "$uname" = "Darwin" ]; then
+        echo "osx"
+        return 0
+    elif [ -n "$runtime_id" ]; then
+        echo $(get_legacy_os_name_from_platform "${runtime_id%-*}" || echo "${runtime_id%-*}")
+        return 0
+    else
+        if [ -e /etc/os-release ]; then
+            . /etc/os-release
+            os=$(get_legacy_os_name_from_platform "$ID${VERSION_ID:+.${VERSION_ID}}" || echo "")
+            if [ -n "$os" ]; then
+                echo "$os"
+                return 0
+            fi
+        fi
+    fi
+
+    say_verbose "Distribution specific OS name and version could not be detected: UName = $uname"
+    return 1
+}
+
+get_linux_platform_name() {
+    eval $invocation
+
+    if [ -n "$runtime_id" ]; then
+        echo "${runtime_id%-*}"
+        return 0
+    else
+        if [ -e /etc/os-release ]; then
+            . /etc/os-release
+            echo "$ID${VERSION_ID:+.${VERSION_ID}}"
+            return 0
+        elif [ -e /etc/redhat-release ]; then
+            local redhatRelease=$(</etc/redhat-release)
+            if [[ $redhatRelease == "CentOS release 6."* || $redhatRelease == "Red Hat Enterprise Linux "*" release 6."* ]]; then
+                echo "rhel.6"
+                return 0
+            fi
+        fi
+    fi
+
+    say_verbose "Linux specific platform name and version could not be detected: UName = $uname"
+    return 1
+}
+
+is_musl_based_distro() {
+    (ldd --version 2>&1 || true) | grep -q musl
+}
+
+get_current_os_name() {
+    eval $invocation
+
+    local uname=$(uname)
+    if [ "$uname" = "Darwin" ]; then
+        echo "osx"
+        return 0
+    elif [ "$uname" = "FreeBSD" ]; then
+        echo "freebsd"
+        return 0
+    elif [ "$uname" = "Linux" ]; then
+        local linux_platform_name=""
+        linux_platform_name="$(get_linux_platform_name)" || true
+
+        if [ "$linux_platform_name" = "rhel.6" ]; then
+            echo $linux_platform_name
+            return 0
+        elif is_musl_based_distro; then
+            echo "linux-musl"
+            return 0
+        elif [ "$linux_platform_name" = "linux-musl" ]; then
+            echo "linux-musl"
+            return 0
+        else
+            echo "linux"
+            return 0
+        fi
+    fi
+
+    say_err "OS name could not be detected: UName = $uname"
+    return 1
+}
+
+machine_has() {
+    eval $invocation
+
+    command -v "$1" > /dev/null 2>&1
+    return $?
+}
+
+check_min_reqs() {
+    local hasMinimum=false
+    if machine_has "curl"; then
+        hasMinimum=true
+    elif machine_has "wget"; then
+        hasMinimum=true
+    fi
+
+    if [ "$hasMinimum" = "false" ]; then
+        say_err "curl (recommended) or wget are required to download dotnet. Install missing prerequisite to proceed."
+        return 1
+    fi
+    return 0
+}
+
+# args:
+# input - $1
+to_lowercase() {
+    #eval $invocation
+
+    echo "$1" | tr '[:upper:]' '[:lower:]'
+    return 0
+}
+
+# args:
+# input - $1
+remove_trailing_slash() {
+    #eval $invocation
+
+    local input="${1:-}"
+    echo "${input%/}"
+    return 0
+}
+
+# args:
+# input - $1
+remove_beginning_slash() {
+    #eval $invocation
+
+    local input="${1:-}"
+    echo "${input#/}"
+    return 0
+}
+
+# args:
+# root_path - $1
+# child_path - $2 - this parameter can be empty
+combine_paths() {
+    eval $invocation
+
+    # TODO: Consider making it work with any number of paths. For now:
+    if [ ! -z "${3:-}" ]; then
+        say_err "combine_paths: Function takes two parameters."
+        return 1
+    fi
+
+    local root_path="$(remove_trailing_slash "$1")"
+    local child_path="$(remove_beginning_slash "${2:-}")"
+    say_verbose "combine_paths: root_path=$root_path"
+    say_verbose "combine_paths: child_path=$child_path"
+    echo "$root_path/$child_path"
+    return 0
+}
+
+get_machine_architecture() {
+    eval $invocation
+
+    if command -v uname > /dev/null; then
+        CPUName=$(uname -m)
+        case $CPUName in
+        armv1*|armv2*|armv3*|armv4*|armv5*|armv6*)
+            echo "armv6-or-below"
+            return 0
+            ;;
+        armv*l)
+            echo "arm"
+            return 0
+            ;;
+        aarch64|arm64)
+            if [ "$(getconf LONG_BIT)" -lt 64 ]; then
+                # This is 32-bit OS running on 64-bit CPU (for example Raspberry Pi OS)
+                echo "arm"
+                return 0
+            fi
+            echo "arm64"
+            return 0
+            ;;
+        s390x)
+            echo "s390x"
+            return 0
+            ;;
+        ppc64le)
+            echo "ppc64le"
+            return 0
+            ;;
+        loongarch64)
+            echo "loongarch64"
+            return 0
+            ;;
+        riscv64)
+            echo "riscv64"
+            return 0
+            ;;
+        powerpc|ppc)
+            echo "ppc"
+            return 0
+            ;;
+        esac
+    fi
+
+    # Always default to 'x64'
+    echo "x64"
+    return 0
+}
+
+# args:
+# architecture - $1
+get_normalized_architecture_from_architecture() {
+    eval $invocation
+
+    local architecture="$(to_lowercase "$1")"
+
+    if [[ $architecture == \<auto\> ]]; then
+        machine_architecture="$(get_machine_architecture)"
+        if [[ "$machine_architecture" == "armv6-or-below" ]]; then
+            say_err "Architecture \`$machine_architecture\` not supported. If you think this is a bug, report it at https://github.com/dotnet/install-scripts/issues"
+            return 1
+        fi
+
+        echo $machine_architecture
+        return 0
+    fi
+
+    case "$architecture" in
+        amd64|x64)
+            echo "x64"
+            return 0
+            ;;
+        arm)
+            echo "arm"
+            return 0
+            ;;
+        arm64)
+            echo "arm64"
+            return 0
+            ;;
+        s390x)
+            echo "s390x"
+            return 0
+            ;;
+        ppc64le)
+            echo "ppc64le"
+            return 0
+            ;;
+        loongarch64)
+            echo "loongarch64"
+            return 0
+            ;;
+    esac
+
+    say_err "Architecture \`$architecture\` not supported. If you think this is a bug, report it at https://github.com/dotnet/install-scripts/issues"
+    return 1
+}
+
+# args:
+# version - $1
+# channel - $2
+# architecture - $3
+get_normalized_architecture_for_specific_sdk_version() {
+    eval $invocation
+
+    local is_version_support_arm64="$(is_arm64_supported "$1")"
+    local is_channel_support_arm64="$(is_arm64_supported "$2")"
+    local architecture="$3";
+    local osname="$(get_current_os_name)"
+
+    if [ "$osname" == "osx" ] && [ "$architecture" == "arm64" ] && { [ "$is_version_support_arm64" = false ] || [ "$is_channel_support_arm64" = false ]; }; then
+        #check if rosetta is installed
+        if [ "$(/usr/bin/pgrep oahd >/dev/null 2>&1;echo $?)" -eq 0 ]; then 
+            say_verbose "Changing user architecture from '$architecture' to 'x64' because .NET SDKs prior to version 6.0 do not support arm64." 
+            echo "x64"
+            return 0;
+        else
+            say_err "Architecture \`$architecture\` is not supported for .NET SDK version \`$version\`. Please install Rosetta to allow emulation of the \`$architecture\` .NET SDK on this platform"
+            return 1
+        fi
+    fi
+
+    echo "$architecture"
+    return 0
+}
+
+# args:
+# version or channel - $1
+is_arm64_supported() {
+    # Extract the major version by splitting on the dot
+    major_version="${1%%.*}"
+
+    # Check if the major version is a valid number and less than 6
+    case "$major_version" in
+        [0-9]*)  
+            if [ "$major_version" -lt 6 ]; then
+                echo false
+                return 0
+            fi
+            ;;
+    esac
+
+    echo true
+    return 0
+}
+
+# args:
+# user_defined_os - $1
+get_normalized_os() {
+    eval $invocation
+
+    local osname="$(to_lowercase "$1")"
+    if [ ! -z "$osname" ]; then
+        case "$osname" in
+            osx | freebsd | rhel.6 | linux-musl | linux)
+                echo "$osname"
+                return 0
+                ;;
+            macos)
+                osname='osx'
+                echo "$osname"
+                return 0
+                ;;
+            *)
+                say_err "'$user_defined_os' is not a supported value for --os option, supported values are: osx, macos, linux, linux-musl, freebsd, rhel.6. If you think this is a bug, report it at https://github.com/dotnet/install-scripts/issues."
+                return 1
+                ;;
+        esac
+    else
+        osname="$(get_current_os_name)" || return 1
+    fi
+    echo "$osname"
+    return 0
+}
+
+# args:
+# quality - $1
+get_normalized_quality() {
+    eval $invocation
+
+    local quality="$(to_lowercase "$1")"
+    if [ ! -z "$quality" ]; then
+        case "$quality" in
+            daily | preview)
+                echo "$quality"
+                return 0
+                ;;
+            ga)
+                #ga quality is available without specifying quality, so normalizing it to empty
+                return 0
+                ;;
+            *)
+                say_err "'$quality' is not a supported value for --quality option. Supported values are: daily, preview, ga. If you think this is a bug, report it at https://github.com/dotnet/install-scripts/issues."
+                return 1
+                ;;
+        esac
+    fi
+    return 0
+}
+
+# args:
+# channel - $1
+get_normalized_channel() {
+    eval $invocation
+
+    local channel="$(to_lowercase "$1")"
+
+    if [[ $channel == current ]]; then
+        say_warning 'Value "Current" is deprecated for -Channel option. Use "STS" instead.'
+    fi
+
+    if [[ $channel == release/* ]]; then
+        say_warning 'Using branch name with -Channel option is no longer supported with newer releases. Use -Quality option with a channel in X.Y format instead.';
+    fi
+
+    if [ ! -z "$channel" ]; then
+        case "$channel" in
+            lts)
+                echo "LTS"
+                return 0
+                ;;
+            sts)
+                echo "STS"
+                return 0
+                ;;
+            current)
+                echo "STS"
+                return 0
+                ;;
+            *)
+                echo "$channel"
+                return 0
+                ;;
+        esac
+    fi
+
+    return 0
+}
+
+# args:
+# runtime - $1
+get_normalized_product() {
+    eval $invocation
+
+    local product=""
+    local runtime="$(to_lowercase "$1")"
+    if [[ "$runtime" == "dotnet" ]]; then
+        product="dotnet-runtime"
+    elif [[ "$runtime" == "aspnetcore" ]]; then
+        product="aspnetcore-runtime"
+    elif [ -z "$runtime" ]; then
+        product="dotnet-sdk"
+    fi
+    echo "$product"
+    return 0
+}
+
+# The version text returned from the feeds is a 1-line or 2-line string:
+# For the SDK and the dotnet runtime (2 lines):
+# Line 1: # commit_hash
+# Line 2: # 4-part version
+# For the aspnetcore runtime (1 line):
+# Line 1: # 4-part version
+
+# args:
+# version_text - stdin
+get_version_from_latestversion_file_content() {
+    eval $invocation
+
+    cat | tail -n 1 | sed 's/\r$//'
+    return 0
+}
+
+# args:
+# install_root - $1
+# relative_path_to_package - $2
+# specific_version - $3
+is_dotnet_package_installed() {
+    eval $invocation
+
+    local install_root="$1"
+    local relative_path_to_package="$2"
+    local specific_version="${3//[$'\t\r\n']}"
+
+    local dotnet_package_path="$(combine_paths "$(combine_paths "$install_root" "$relative_path_to_package")" "$specific_version")"
+    say_verbose "is_dotnet_package_installed: dotnet_package_path=$dotnet_package_path"
+
+    if [ -d "$dotnet_package_path" ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# args:
+# downloaded file - $1
+# remote_file_size - $2
+validate_remote_local_file_sizes() 
+{
+    eval $invocation
+
+    local downloaded_file="$1"
+    local remote_file_size="$2"
+    local file_size=''
+
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        file_size="$(stat -c '%s' "$downloaded_file")"
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        # hardcode in order to avoid conflicts with GNU stat
+        file_size="$(/usr/bin/stat -f '%z' "$downloaded_file")"
+    fi  
+    
+    if [ -n "$file_size" ]; then
+        say "Downloaded file size is $file_size bytes."
+
+        if [ -n "$remote_file_size" ] && [ -n "$file_size" ]; then
+            if [ "$remote_file_size" -ne "$file_size" ]; then
+                say "The remote and local file sizes are not equal. The remote file size is $remote_file_size bytes and the local size is $file_size bytes. The local package may be corrupted."
+            else
+                say "The remote and local file sizes are equal."
+            fi
+        fi
+        
+    else
+        say "Either downloaded or local package size can not be measured. One of them may be corrupted."      
+    fi 
+}
+
+# args:
+# azure_feed - $1
+# channel - $2
+# normalized_architecture - $3
+get_version_from_latestversion_file() {
+    eval $invocation
+
+    local azure_feed="$1"
+    local channel="$2"
+    local normalized_architecture="$3"
+
+    local version_file_url=null
+    if [[ "$runtime" == "dotnet" ]]; then
+        version_file_url="$azure_feed/Runtime/$channel/latest.version"
+    elif [[ "$runtime" == "aspnetcore" ]]; then
+        version_file_url="$azure_feed/aspnetcore/Runtime/$channel/latest.version"
+    elif [ -z "$runtime" ]; then
+         version_file_url="$azure_feed/Sdk/$channel/latest.version"
+    else
+        say_err "Invalid value for \$runtime"
+        return 1
+    fi
+    say_verbose "get_version_from_latestversion_file: latest url: $version_file_url"
+
+    download "$version_file_url" || return $?
+    return 0
+}
+
+# args:
+# json_file - $1
+parse_globaljson_file_for_version() {
+    eval $invocation
+
+    local json_file="$1"
+    if [ ! -f "$json_file" ]; then
+        say_err "Unable to find \`$json_file\`"
+        return 1
+    fi
+
+    sdk_section=$(cat "$json_file" | tr -d "\r" | awk '/"sdk"/,/}/')
+    if [ -z "$sdk_section" ]; then
+        say_err "Unable to parse the SDK node in \`$json_file\`"
+        return 1
+    fi
+
+    sdk_list=$(echo $sdk_section | awk -F"[{}]" '{print $2}')
+    sdk_list=${sdk_list//[\" ]/}
+    sdk_list=${sdk_list//,/$'\n'}
+
+    local version_info=""
+    while read -r line; do
+      IFS=:
+      while read -r key value; do
+        if [[ "$key" == "version" ]]; then
+          version_info=$value
+        fi
+      done <<< "$line"
+    done <<< "$sdk_list"
+    if [ -z "$version_info" ]; then
+        say_err "Unable to find the SDK:version node in \`$json_file\`"
+        return 1
+    fi
+
+    unset IFS;
+    echo "$version_info"
+    return 0
+}
+
+# args:
+# azure_feed - $1
+# channel - $2
+# normalized_architecture - $3
+# version - $4
+# json_file - $5
+get_specific_version_from_version() {
+    eval $invocation
+
+    local azure_feed="$1"
+    local channel="$2"
+    local normalized_architecture="$3"
+    local version="$(to_lowercase "$4")"
+    local json_file="$5"
+
+    if [ -z "$json_file" ]; then
+        if [[ "$version" == "latest" ]]; then
+            local version_info
+            version_info="$(get_version_from_latestversion_file "$azure_feed" "$channel" "$normalized_architecture" false)" || return 1
+            say_verbose "get_specific_version_from_version: version_info=$version_info"
+            echo "$version_info" | get_version_from_latestversion_file_content
+            return 0
+        else
+            echo "$version"
+            return 0
+        fi
+    else
+        local version_info
+        version_info="$(parse_globaljson_file_for_version "$json_file")" || return 1
+        echo "$version_info"
+        return 0
+    fi
+}
+
+# args:
+# azure_feed - $1
+# channel - $2
+# normalized_architecture - $3
+# specific_version - $4
+# normalized_os - $5
+construct_download_link() {
+    eval $invocation
+
+    local azure_feed="$1"
+    local channel="$2"
+    local normalized_architecture="$3"
+    local specific_version="${4//[$'\t\r\n']}"
+    local specific_product_version="$(get_specific_product_version "$1" "$4")"
+    local osname="$5"
+
+    local download_link=null
+    if [[ "$runtime" == "dotnet" ]]; then
+        download_link="$azure_feed/Runtime/$specific_version/dotnet-runtime-$specific_product_version-$osname-$normalized_architecture.tar.gz"
+    elif [[ "$runtime" == "aspnetcore" ]]; then
+        download_link="$azure_feed/aspnetcore/Runtime/$specific_version/aspnetcore-runtime-$specific_product_version-$osname-$normalized_architecture.tar.gz"
+    elif [ -z "$runtime" ]; then
+        download_link="$azure_feed/Sdk/$specific_version/dotnet-sdk-$specific_product_version-$osname-$normalized_architecture.tar.gz"
+    else
+        return 1
+    fi
+
+    echo "$download_link"
+    return 0
+}
+
+# args:
+# azure_feed - $1
+# specific_version - $2
+# download link - $3 (optional)
+get_specific_product_version() {
+    # If we find a 'productVersion.txt' at the root of any folder, we'll use its contents
+    # to resolve the version of what's in the folder, superseding the specified version.
+    # if 'productVersion.txt' is missing but download link is already available, product version will be taken from download link
+    eval $invocation
+
+    local azure_feed="$1"
+    local specific_version="${2//[$'\t\r\n']}"
+    local package_download_link=""
+    if [ $# -gt 2  ]; then
+        local package_download_link="$3"
+    fi
+    local specific_product_version=null
+
+    # Try to get the version number, using the productVersion.txt file located next to the installer file.
+    local download_links=($(get_specific_product_version_url "$azure_feed" "$specific_version" true "$package_download_link")
+        $(get_specific_product_version_url "$azure_feed" "$specific_version" false "$package_download_link"))
+
+    for download_link in "${download_links[@]}"
+    do
+        say_verbose "Checking for the existence of $download_link"
+
+        if machine_has "curl"
+        then
+            if ! specific_product_version=$(curl -sL --fail "${download_link}${feed_credential}" 2>&1); then
+                continue
+            else
+                echo "${specific_product_version//[$'\t\r\n']}"
+                return 0
+            fi
+
+        elif machine_has "wget"
+        then
+            specific_product_version=$(wget -qO- "${download_link}${feed_credential}" 2>&1)
+            if [ $? = 0 ]; then
+                echo "${specific_product_version//[$'\t\r\n']}"
+                return 0
+            fi
+        fi
+    done
+    
+    # Getting the version number with productVersion.txt has failed. Try parsing the download link for a version number.
+    say_verbose "Failed to get the version using productVersion.txt file. Download link will be parsed instead."
+    specific_product_version="$(get_product_specific_version_from_download_link "$package_download_link" "$specific_version")"
+    echo "${specific_product_version//[$'\t\r\n']}"
+    return 0
+}
+
+# args:
+# azure_feed - $1
+# specific_version - $2
+# is_flattened - $3
+# download link - $4 (optional)
+get_specific_product_version_url() {
+    eval $invocation
+
+    local azure_feed="$1"
+    local specific_version="$2"
+    local is_flattened="$3"
+    local package_download_link=""
+    if [ $# -gt 3  ]; then
+        local package_download_link="$4"
+    fi
+
+    local pvFileName="productVersion.txt"
+    if [ "$is_flattened" = true ]; then
+        if [ -z "$runtime" ]; then
+            pvFileName="sdk-productVersion.txt"
+        elif [[ "$runtime" == "dotnet" ]]; then
+            pvFileName="runtime-productVersion.txt"
+        else
+            pvFileName="$runtime-productVersion.txt"
+        fi
+    fi
+
+    local download_link=null
+
+    if [ -z "$package_download_link" ]; then
+        if [[ "$runtime" == "dotnet" ]]; then
+            download_link="$azure_feed/Runtime/$specific_version/${pvFileName}"
+        elif [[ "$runtime" == "aspnetcore" ]]; then
+            download_link="$azure_feed/aspnetcore/Runtime/$specific_version/${pvFileName}"
+        elif [ -z "$runtime" ]; then
+            download_link="$azure_feed/Sdk/$specific_version/${pvFileName}"
+        else
+            return 1
+        fi
+    else
+        download_link="${package_download_link%/*}/${pvFileName}"
+    fi
+
+    say_verbose "Constructed productVersion link: $download_link"
+    echo "$download_link"
+    return 0
+}
+
+# args:
+# download link - $1
+# specific version - $2
+get_product_specific_version_from_download_link()
+{
+    eval $invocation
+
+    local download_link="$1"
+    local specific_version="$2"
+    local specific_product_version="" 
+
+    if [ -z "$download_link" ]; then
+        echo "$specific_version"
+        return 0
+    fi
+
+    #get filename
+    filename="${download_link##*/}"
+
+    #product specific version follows the product name
+    #for filename 'dotnet-sdk-3.1.404-linux-x64.tar.gz': the product version is 3.1.404
+    IFS='-'
+    read -ra filename_elems <<< "$filename"
+    count=${#filename_elems[@]}
+    if [[ "$count" -gt 2 ]]; then
+        specific_product_version="${filename_elems[2]}"
+    else
+        specific_product_version=$specific_version
+    fi
+    unset IFS;
+    echo "$specific_product_version"
+    return 0
+}
+
+# args:
+# azure_feed - $1
+# channel - $2
+# normalized_architecture - $3
+# specific_version - $4
+construct_legacy_download_link() {
+    eval $invocation
+
+    local azure_feed="$1"
+    local channel="$2"
+    local normalized_architecture="$3"
+    local specific_version="${4//[$'\t\r\n']}"
+
+    local distro_specific_osname
+    distro_specific_osname="$(get_legacy_os_name)" || return 1
+
+    local legacy_download_link=null
+    if [[ "$runtime" == "dotnet" ]]; then
+        legacy_download_link="$azure_feed/Runtime/$specific_version/dotnet-$distro_specific_osname-$normalized_architecture.$specific_version.tar.gz"
+    elif [ -z "$runtime" ]; then
+        legacy_download_link="$azure_feed/Sdk/$specific_version/dotnet-dev-$distro_specific_osname-$normalized_architecture.$specific_version.tar.gz"
+    else
+        return 1
+    fi
+
+    echo "$legacy_download_link"
+    return 0
+}
+
+get_user_install_path() {
+    eval $invocation
+
+    if [ ! -z "${DOTNET_INSTALL_DIR:-}" ]; then
+        echo "$DOTNET_INSTALL_DIR"
+    else
+        echo "$HOME/.dotnet"
+    fi
+    return 0
+}
+
+# args:
+# install_dir - $1
+resolve_installation_path() {
+    eval $invocation
+
+    local install_dir=$1
+    if [ "$install_dir" = "<auto>" ]; then
+        local user_install_path="$(get_user_install_path)"
+        say_verbose "resolve_installation_path: user_install_path=$user_install_path"
+        echo "$user_install_path"
+        return 0
+    fi
+
+    echo "$install_dir"
+    return 0
+}
+
+# args:
+# relative_or_absolute_path - $1
+get_absolute_path() {
+    eval $invocation
+
+    local relative_or_absolute_path=$1
+    echo "$(cd "$(dirname "$1")" && pwd -P)/$(basename "$1")"
+    return 0
+}
+
+# args:
+# override - $1 (boolean, true or false)
+get_cp_options() {
+    eval $invocation
+
+    local override="$1"
+    local override_switch=""
+
+    if [ "$override" = false ]; then
+        override_switch="-n"
+
+        # create temporary files to check if 'cp -u' is supported
+        tmp_dir="$(mktemp -d)"
+        tmp_file="$tmp_dir/testfile"
+        tmp_file2="$tmp_dir/testfile2"
+
+        touch "$tmp_file"
+
+        # use -u instead of -n if it's available
+        if cp -u "$tmp_file" "$tmp_file2" 2>/dev/null; then
+            override_switch="-u"
+        fi
+
+        # clean up
+        rm -f "$tmp_file" "$tmp_file2"
+        rm -rf "$tmp_dir"
+    fi
+
+    echo "$override_switch"
+}
+
+# args:
+# input_files - stdin
+# root_path - $1
+# out_path - $2
+# override - $3
+copy_files_or_dirs_from_list() {
+    eval $invocation
+
+    local root_path="$(remove_trailing_slash "$1")"
+    local out_path="$(remove_trailing_slash "$2")"
+    local override="$3"
+    local override_switch="$(get_cp_options "$override")"
+
+    cat | uniq | while read -r file_path; do
+        local path="$(remove_beginning_slash "${file_path#$root_path}")"
+        local target="$out_path/$path"
+        if [ "$override" = true ] || (! ([ -d "$target" ] || [ -e "$target" ] || [ -L "$target" ])); then
+            mkdir -p "$out_path/$(dirname "$path")"
+            if [ -d "$target" ] || [ -L "$target" ]; then
+                rm -rf "$target"
+            fi
+            cp -RP $override_switch "$root_path/$path" "$target"
+        fi
+    done
+}
+
+# args:
+# zip_uri - $1
+get_remote_file_size() {
+    local zip_uri="$1"
+
+    if machine_has "curl"; then
+        file_size=$(curl -sI  "$zip_uri" | grep -i content-length | awk '{ num = $2 + 0; print num }')
+    elif machine_has "wget"; then
+        file_size=$(wget --spider --server-response -O /dev/null "$zip_uri" 2>&1 | grep -i 'Content-Length:' | awk '{ num = $2 + 0; print num }')
+    else
+        say "Neither curl nor wget is available on this system."
+        return
+    fi
+
+    if [ -n "$file_size" ]; then
+        say "Remote file $zip_uri size is $file_size bytes."
+        echo "$file_size"
+    else
+        say_verbose "Content-Length header was not extracted for $zip_uri."
+        echo ""
+    fi
+}
+
+# args:
+# zip_path - $1
+# out_path - $2
+# remote_file_size - $3
+extract_dotnet_package() {
+    eval $invocation
+
+    local zip_path="$1"
+    local out_path="$2"
+    local remote_file_size="$3"
+
+    local temp_out_path="$(mktemp -d "$temporary_file_template")"
+
+    local failed=false
+    tar -xzf "$zip_path" -C "$temp_out_path" > /dev/null || failed=true
+
+    local folders_with_version_regex='^.*/[0-9]+\.[0-9]+[^/]+/'
+    find "$temp_out_path" \( -type f -o -type l \) | grep -Eo "$folders_with_version_regex" | sort | copy_files_or_dirs_from_list "$temp_out_path" "$out_path" false
+    find "$temp_out_path" \( -type f -o -type l \) | grep -Ev "$folders_with_version_regex" | copy_files_or_dirs_from_list "$temp_out_path" "$out_path" "$override_non_versioned_files"
+    
+    validate_remote_local_file_sizes "$zip_path" "$remote_file_size"
+    
+    rm -rf "$temp_out_path"
+    if [ -z ${keep_zip+x} ]; then
+        rm -f "$zip_path" && say_verbose "Temporary archive file $zip_path was removed"
+    fi
+
+    if [ "$failed" = true ]; then
+        say_err "Extraction failed"
+        return 1
+    fi
+    return 0
+}
+
+# args:
+# remote_path - $1
+# disable_feed_credential - $2
+get_http_header()
+{
+    eval $invocation
+    local remote_path="$1"
+    local disable_feed_credential="$2"
+
+    local failed=false
+    local response
+    if machine_has "curl"; then
+        get_http_header_curl $remote_path $disable_feed_credential || failed=true
+    elif machine_has "wget"; then
+        get_http_header_wget $remote_path $disable_feed_credential || failed=true
+    else
+        failed=true
+    fi
+    if [ "$failed" = true ]; then
+        say_verbose "Failed to get HTTP header: '$remote_path'."
+        return 1
+    fi
+    return 0
+}
+
+# args:
+# remote_path - $1
+# disable_feed_credential - $2
+get_http_header_curl() {
+    eval $invocation
+    local remote_path="$1"
+    local disable_feed_credential="$2"
+
+    remote_path_with_credential="$remote_path"
+    if [ "$disable_feed_credential" = false ]; then
+        remote_path_with_credential+="$feed_credential"
+    fi
+
+    curl_options="-I -sSL --retry 5 --retry-delay 2 --connect-timeout 15 "
+    curl $curl_options "$remote_path_with_credential" 2>&1 || return 1
+    return 0
+}
+
+# args:
+# remote_path - $1
+# disable_feed_credential - $2
+get_http_header_wget() {
+    eval $invocation
+    local remote_path="$1"
+    local disable_feed_credential="$2"
+    local wget_options="-q -S --spider --tries 5 "
+
+    local wget_options_extra=''
+
+    # Test for options that aren't supported on all wget implementations.
+    if [[ $(wget -h 2>&1 | grep -E 'waitretry|connect-timeout') ]]; then
+        wget_options_extra="--waitretry 2 --connect-timeout 15 "
+    else
+        say "wget extra options are unavailable for this environment"
+    fi
+
+    remote_path_with_credential="$remote_path"
+    if [ "$disable_feed_credential" = false ]; then
+        remote_path_with_credential+="$feed_credential"
+    fi
+
+    wget $wget_options $wget_options_extra "$remote_path_with_credential" 2>&1
+
+    return $?
+}
+
+# args:
+# remote_path - $1
+# [out_path] - $2 - stdout if not provided
+download() {
+    eval $invocation
+
+    local remote_path="$1"
+    local out_path="${2:-}"
+
+    if [[ "$remote_path" != "http"* ]]; then
+        cp "$remote_path" "$out_path"
+        return $?
+    fi
+
+    local failed=false
+    local attempts=0
+    while [ $attempts -lt 3 ]; do
+        attempts=$((attempts+1))
+        failed=false
+        if machine_has "curl"; then
+            downloadcurl "$remote_path" "$out_path" || failed=true
+        elif machine_has "wget"; then
+            downloadwget "$remote_path" "$out_path" || failed=true
+        else
+            say_err "Missing dependency: neither curl nor wget was found."
+            exit 1
+        fi
+
+        if [ "$failed" = false ] || [ $attempts -ge 3 ] || { [ -n "${http_code-}" ] && [ "${http_code}" = "404" ]; }; then
+            break
+        fi
+
+        say "Download attempt #$attempts has failed: ${http_code-} ${download_error_msg-}"
+        say "Attempt #$((attempts+1)) will start in $((attempts*10)) seconds."
+        sleep $((attempts*10))
+    done
+
+    if [ "$failed" = true ]; then
+        say_verbose "Download failed: $remote_path"
+        return 1
+    fi
+    return 0
+}
+
+# Updates global variables $http_code and $download_error_msg
+downloadcurl() {
+    eval $invocation
+    unset http_code
+    unset download_error_msg
+    local remote_path="$1"
+    local out_path="${2:-}"
+    # Append feed_credential as late as possible before calling curl to avoid logging feed_credential
+    # Avoid passing URI with credentials to functions: note, most of them echoing parameters of invocation in verbose output.
+    local remote_path_with_credential="${remote_path}${feed_credential}"
+    local curl_options="--retry 20 --retry-delay 2 --connect-timeout 15 -sSL -f --create-dirs "
+    local curl_exit_code=0;
+    if [ -z "$out_path" ]; then
+        curl_output=$(curl $curl_options "$remote_path_with_credential" 2>&1)
+        curl_exit_code=$?
+        echo "$curl_output"
+    else
+        curl_output=$(curl $curl_options -o "$out_path" "$remote_path_with_credential" 2>&1)
+        curl_exit_code=$?
+    fi
+
+    # Regression in curl causes curl with --retry to return a 0 exit code even when it fails to download a file - https://github.com/curl/curl/issues/17554
+    if [ $curl_exit_code -eq 0 ] && echo "$curl_output" | grep -q "^curl: ([0-9]*) "; then
+        curl_exit_code=$(echo "$curl_output" | sed 's/curl: (\([0-9]*\)).*/\1/')
+    fi
+
+    if [ $curl_exit_code -gt 0 ]; then
+        download_error_msg="Unable to download $remote_path."
+        # Check for curl timeout codes
+        if [[ $curl_exit_code == 7 || $curl_exit_code == 28 ]]; then
+            download_error_msg+=" Failed to reach the server: connection timeout."
+        else
+            local disable_feed_credential=false
+            local response=$(get_http_header_curl $remote_path $disable_feed_credential)
+            http_code=$( echo "$response" | awk '/^HTTP/{print $2}' | tail -1 )
+            if  [[ ! -z $http_code && $http_code != 2* ]]; then
+                download_error_msg+=" Returned HTTP status code: $http_code."
+            fi
+        fi
+        say_verbose "$download_error_msg"
+        return 1
+    fi
+    return 0
+}
+
+
+# Updates global variables $http_code and $download_error_msg
+downloadwget() {
+    eval $invocation
+    unset http_code
+    unset download_error_msg
+    local remote_path="$1"
+    local out_path="${2:-}"
+    # Append feed_credential as late as possible before calling wget to avoid logging feed_credential
+    local remote_path_with_credential="${remote_path}${feed_credential}"
+    local wget_options="--tries 20 "
+
+    local wget_options_extra=''
+    local wget_result=''
+
+    # Test for options that aren't supported on all wget implementations.
+    if [[ $(wget -h 2>&1 | grep -E 'waitretry|connect-timeout') ]]; then
+        wget_options_extra="--waitretry 2 --connect-timeout 15 "
+    else
+        say "wget extra options are unavailable for this environment"
+    fi
+
+    if [ -z "$out_path" ]; then
+        wget -q $wget_options $wget_options_extra -O - "$remote_path_with_credential" 2>&1
+        wget_result=$?
+    else
+        wget $wget_options $wget_options_extra -O "$out_path" "$remote_path_with_credential" 2>&1
+        wget_result=$?
+    fi
+
+    if [[ $wget_result != 0 ]]; then
+        local disable_feed_credential=false
+        local response=$(get_http_header_wget $remote_path $disable_feed_credential)
+        http_code=$( echo "$response" | awk '/^  HTTP/{print $2}' | tail -1 )
+        download_error_msg="Unable to download $remote_path."
+        if  [[ ! -z $http_code && $http_code != 2* ]]; then
+            download_error_msg+=" Returned HTTP status code: $http_code."
+        # wget exit code 4 stands for network-issue
+        elif [[ $wget_result == 4 ]]; then
+            download_error_msg+=" Failed to reach the server: connection timeout."
+        fi
+        say_verbose "$download_error_msg"
+        return 1
+    fi
+
+    return 0
+}
+
+get_download_link_from_aka_ms() {
+    eval $invocation
+
+    #quality is not supported for LTS or STS channel
+    #STS maps to current
+    if [[ ! -z "$normalized_quality"  && ("$normalized_channel" == "LTS" || "$normalized_channel" == "STS") ]]; then
+        normalized_quality=""
+        say_warning "Specifying quality for STS or LTS channel is not supported, the quality will be ignored."
+    fi
+
+    say_verbose "Retrieving primary payload URL from aka.ms for channel: '$normalized_channel', quality: '$normalized_quality', product: '$normalized_product', os: '$normalized_os', architecture: '$normalized_architecture'." 
+
+    #construct aka.ms link
+    aka_ms_link="https://aka.ms/dotnet"
+    if  [ "$internal" = true ]; then
+        aka_ms_link="$aka_ms_link/internal"
+    fi
+    aka_ms_link="$aka_ms_link/$normalized_channel"
+    if [[ ! -z "$normalized_quality" ]]; then
+        aka_ms_link="$aka_ms_link/$normalized_quality"
+    fi
+    aka_ms_link="$aka_ms_link/$normalized_product-$normalized_os-$normalized_architecture.tar.gz"
+    say_verbose "Constructed aka.ms link: '$aka_ms_link'."
+
+    #get HTTP response
+    #do not pass credentials as a part of the $aka_ms_link and do not apply credentials in the get_http_header function
+    #otherwise the redirect link would have credentials as well
+    #it would result in applying credentials twice to the resulting link and thus breaking it, and in echoing credentials to the output as a part of redirect link
+    disable_feed_credential=true
+    response="$(get_http_header $aka_ms_link $disable_feed_credential)"
+
+    say_verbose "Received response: $response"
+    # Get results of all the redirects.
+    http_codes=$( echo "$response" | awk '$1 ~ /^HTTP/ {print $2}' )
+    # Allow intermediate 301 redirects and tolerate proxy-injected 200s
+    broken_redirects=$( echo "$http_codes" | sed '$d' | grep -vE '^(301|200)$' )
+    # The response may end without final code 2xx/4xx/5xx somehow, e.g. network restrictions on www.bing.com causes redirecting to bing.com fails with connection refused.
+    # In this case it should not exclude the last.
+    last_http_code=$(  echo "$http_codes" | tail -n 1 )
+    if ! [[ $last_http_code =~ ^(2|4|5)[0-9][0-9]$ ]]; then
+        broken_redirects=$( echo "$http_codes" | grep -vE '^(301|200)$' )
+    fi
+
+    # All HTTP codes are 301 (Moved Permanently), the redirect link exists.
+    if [[ -z "$broken_redirects" ]]; then
+        aka_ms_download_link=$( echo "$response" | awk '$1 ~ /^Location/{print $2}' | tail -1 | tr -d '\r')
+
+        if [[ -z "$aka_ms_download_link" ]]; then
+            say_verbose "The aka.ms link '$aka_ms_link' is not valid: failed to get redirect location."
+            return 1
+        fi
+
+        say_verbose "The redirect location retrieved: '$aka_ms_download_link'."
+        return 0
+    else
+        say_verbose "The aka.ms link '$aka_ms_link' is not valid: received HTTP code: $(echo "$broken_redirects" | paste -sd "," -)."
+        return 1
+    fi
+}
+
+get_feeds_to_use()
+{
+    feeds=(
+    "https://builds.dotnet.microsoft.com/dotnet"
+    "https://ci.dot.net/public"
+    )
+
+    if [[ -n "$azure_feed" ]]; then
+        feeds=("$azure_feed")
+    fi
+
+    if [[ -n "$uncached_feed" ]]; then
+        feeds=("$uncached_feed")
+    fi
+}
+
+# THIS FUNCTION MAY EXIT (if the determined version is already installed).
+generate_download_links() {
+
+    download_links=()
+    specific_versions=()
+    effective_versions=()
+    link_types=()
+
+    # If generate_akams_links returns false, no fallback to old links. Just terminate.
+    # This function may also 'exit' (if the determined version is already installed).
+    generate_akams_links || return
+
+    # Check other feeds only if we haven't been able to find an aka.ms link.
+    if [[ "${#download_links[@]}" -lt 1 ]]; then
+        for feed in ${feeds[@]}
+        do
+            # generate_regular_links may also 'exit' (if the determined version is already installed).
+            generate_regular_links $feed || return
+        done
+    fi
+
+    if [[ "${#download_links[@]}" -eq 0 ]]; then
+        say_err "Failed to resolve the exact version number."
+        return 1
+    fi
+
+    say_verbose "Generated ${#download_links[@]} links."
+    for link_index in ${!download_links[@]}
+    do
+        say_verbose "Link $link_index: ${link_types[$link_index]}, ${effective_versions[$link_index]}, ${download_links[$link_index]}"
+    done
+}
+
+# THIS FUNCTION MAY EXIT (if the determined version is already installed).
+generate_akams_links() {
+    local valid_aka_ms_link=true;
+
+    normalized_version="$(to_lowercase "$version")"
+    if [[ "$normalized_version" != "latest" ]] && [ -n "$normalized_quality" ]; then
+        say_err "Quality and Version options are not allowed to be specified simultaneously. See https://learn.microsoft.com/dotnet/core/tools/dotnet-install-script#options for details."
+        return 1
+    fi
+
+    if [[ -n "$json_file" || "$normalized_version" != "latest" ]]; then
+        # aka.ms links are not needed when exact version is specified via command or json file
+        return
+    fi
+
+    get_download_link_from_aka_ms || valid_aka_ms_link=false
+
+    if [[ "$valid_aka_ms_link" == true ]]; then
+        say_verbose "Retrieved primary payload URL from aka.ms link: '$aka_ms_download_link'."
+        say_verbose "Downloading using legacy url will not be attempted."
+
+        download_link=$aka_ms_download_link
+
+        #get version from the path
+        IFS='/'
+        read -ra pathElems <<< "$download_link"
+        count=${#pathElems[@]}
+        specific_version="${pathElems[count-2]}"
+        unset IFS;
+        say_verbose "Version: '$specific_version'."
+
+        #Retrieve effective version
+        effective_version="$(get_specific_product_version "$azure_feed" "$specific_version" "$download_link")"
+
+        # Add link info to arrays
+        download_links+=($download_link)
+        specific_versions+=($specific_version)
+        effective_versions+=($effective_version)
+        link_types+=("aka.ms")
+
+        #  Check if the SDK version is already installed.
+        if [[ "$dry_run" != true ]] && is_dotnet_package_installed "$install_root" "$asset_relative_path" "$effective_version"; then
+            say "$asset_name with version '$effective_version' is already installed."
+            exit 0
+        fi
+
+        return 0
+    fi
+
+    # if quality is specified - exit with error - there is no fallback approach
+    if [ ! -z "$normalized_quality" ]; then
+        say_err "Failed to locate the latest version in the channel '$normalized_channel' with '$normalized_quality' quality for '$normalized_product', os: '$normalized_os', architecture: '$normalized_architecture'."
+        say_err "Refer to: https://aka.ms/dotnet-os-lifecycle for information on .NET Core support."
+        return 1
+    fi
+    say_verbose "Falling back to latest.version file approach."
+}
+
+# THIS FUNCTION MAY EXIT (if the determined version is already installed)
+# args:
+# feed - $1
+generate_regular_links() {
+    local feed="$1"
+    local valid_legacy_download_link=true
+
+    specific_version=$(get_specific_version_from_version "$feed" "$channel" "$normalized_architecture" "$version" "$json_file") || specific_version='0'
+
+    if [[ "$specific_version" == '0' ]]; then
+        say_verbose "Failed to resolve the specific version number using feed '$feed'"
+        return
+    fi
+
+    effective_version="$(get_specific_product_version "$feed" "$specific_version")"
+    say_verbose "specific_version=$specific_version"
+
+    download_link="$(construct_download_link "$feed" "$channel" "$normalized_architecture" "$specific_version" "$normalized_os")"
+    say_verbose "Constructed primary named payload URL: $download_link"
+
+    # Add link info to arrays
+    download_links+=($download_link)
+    specific_versions+=($specific_version)
+    effective_versions+=($effective_version)
+    link_types+=("primary")
+
+    legacy_download_link="$(construct_legacy_download_link "$feed" "$channel" "$normalized_architecture" "$specific_version")" || valid_legacy_download_link=false
+
+    if [ "$valid_legacy_download_link" = true ]; then
+        say_verbose "Constructed legacy named payload URL: $legacy_download_link"
+    
+        download_links+=($legacy_download_link)
+        specific_versions+=($specific_version)
+        effective_versions+=($effective_version)
+        link_types+=("legacy")
+    else
+        legacy_download_link=""
+        say_verbose "Could not construct a legacy_download_link; omitting..."
+    fi
+
+    #  Check if the SDK version is already installed.
+    if [[ "$dry_run" != true ]] && is_dotnet_package_installed "$install_root" "$asset_relative_path" "$effective_version"; then
+        say "$asset_name with version '$effective_version' is already installed."
+        exit 0
+    fi
+}
+
+print_dry_run() {
+
+    say "Payload URLs:"
+
+    for link_index in "${!download_links[@]}"
+        do
+            say "URL #$link_index - ${link_types[$link_index]}: ${download_links[$link_index]}"
+    done
+
+    resolved_version=${specific_versions[0]}
+    repeatable_command="./$script_name --version "\""$resolved_version"\"" --install-dir "\""$install_root"\"" --architecture "\""$normalized_architecture"\"" --os "\""$normalized_os"\"""
+    
+    if [ ! -z "$normalized_quality" ]; then
+        repeatable_command+=" --quality "\""$normalized_quality"\"""
+    fi
+
+    if [[ "$runtime" == "dotnet" ]]; then
+        repeatable_command+=" --runtime "\""dotnet"\"""
+    elif [[ "$runtime" == "aspnetcore" ]]; then
+        repeatable_command+=" --runtime "\""aspnetcore"\"""
+    fi
+
+    repeatable_command+="$non_dynamic_parameters"
+
+    if [ -n "$feed_credential" ]; then
+        repeatable_command+=" --feed-credential "\""<feed_credential>"\"""
+    fi
+
+    say "Repeatable invocation: $repeatable_command"
+}
+
+calculate_vars() {
+    eval $invocation
+
+    script_name=$(basename "$0")
+    normalized_architecture="$(get_normalized_architecture_from_architecture "$architecture")"
+    say_verbose "Normalized architecture: '$normalized_architecture'."
+    normalized_os="$(get_normalized_os "$user_defined_os")"
+    say_verbose "Normalized OS: '$normalized_os'."
+    normalized_quality="$(get_normalized_quality "$quality")"
+    say_verbose "Normalized quality: '$normalized_quality'."
+    normalized_channel="$(get_normalized_channel "$channel")"
+    say_verbose "Normalized channel: '$normalized_channel'."
+    normalized_product="$(get_normalized_product "$runtime")"
+    say_verbose "Normalized product: '$normalized_product'."
+    install_root="$(resolve_installation_path "$install_dir")"
+    say_verbose "InstallRoot: '$install_root'."
+
+    normalized_architecture="$(get_normalized_architecture_for_specific_sdk_version "$version" "$normalized_channel" "$normalized_architecture")"
+
+    if [[ "$runtime" == "dotnet" ]]; then
+        asset_relative_path="shared/Microsoft.NETCore.App"
+        asset_name=".NET Core Runtime"
+    elif [[ "$runtime" == "aspnetcore" ]]; then
+        asset_relative_path="shared/Microsoft.AspNetCore.App"
+        asset_name="ASP.NET Core Runtime"
+    elif [ -z "$runtime" ]; then
+        asset_relative_path="sdk"
+        asset_name=".NET Core SDK"
+    fi
+
+    get_feeds_to_use
+}
+
+install_dotnet() {
+    eval $invocation
+    local download_failed=false
+    local download_completed=false
+    local remote_file_size=0
+
+    mkdir -p "$install_root"
+    zip_path="${zip_path:-$(mktemp "$temporary_file_template")}"
+    say_verbose "Archive path: $zip_path"
+
+    for link_index in "${!download_links[@]}"
+    do
+        download_link="${download_links[$link_index]}"
+        specific_version="${specific_versions[$link_index]}"
+        effective_version="${effective_versions[$link_index]}"
+        link_type="${link_types[$link_index]}"
+
+        say "Attempting to download using $link_type link $download_link"
+
+        # The download function will set variables $http_code and $download_error_msg in case of failure.
+        download_failed=false
+        download "$download_link" "$zip_path" 2>&1 || download_failed=true
+
+        if [ "$download_failed" = true ]; then
+            case ${http_code-} in
+            404)
+                say "The resource at $link_type link '$download_link' is not available."
+                ;;
+            *)
+                say "Failed to download $link_type link '$download_link': ${http_code-} ${download_error_msg-}"
+                ;;
+            esac
+            rm -f "$zip_path" 2>&1 && say_verbose "Temporary archive file $zip_path was removed"
+        else
+            download_completed=true
+            break
+        fi
+    done
+
+    if [[ "$download_completed" == false ]]; then
+        say_err "Could not find \`$asset_name\` with version = $specific_version"
+        say_err "Refer to: https://aka.ms/dotnet-os-lifecycle for information on .NET Core support"
+        return 1
+    fi
+
+    remote_file_size="$(get_remote_file_size "$download_link")"
+
+    say "Extracting archive from $download_link"
+    extract_dotnet_package "$zip_path" "$install_root" "$remote_file_size" || return 1
+
+    #  Check if the SDK version is installed; if not, fail the installation.
+    # if the version contains "RTM" or "servicing"; check if a 'release-type' SDK version is installed.
+    if [[ $specific_version == *"rtm"* || $specific_version == *"servicing"* ]]; then
+        IFS='-'
+        read -ra verArr <<< "$specific_version"
+        release_version="${verArr[0]}"
+        unset IFS;
+        say_verbose "Checking installation: version = $release_version"
+        if is_dotnet_package_installed "$install_root" "$asset_relative_path" "$release_version"; then
+            say "Installed version is $effective_version"
+            return 0
+        fi
+    fi
+
+    #  Check if the standard SDK version is installed.
+    say_verbose "Checking installation: version = $effective_version"
+    if is_dotnet_package_installed "$install_root" "$asset_relative_path" "$effective_version"; then
+        say "Installed version is $effective_version"
+        return 0
+    fi
+
+    # Version verification failed. More likely something is wrong either with the downloaded content or with the verification algorithm.
+    say_err "Failed to verify the version of installed \`$asset_name\`.\nInstallation source: $download_link.\nInstallation location: $install_root.\nReport the bug at https://github.com/dotnet/install-scripts/issues."
+    say_err "\`$asset_name\` with version = $effective_version failed to install with an error."
+    return 1
+}
+
+args=("$@")
+
+local_version_file_relative_path="/.version"
+bin_folder_relative_path=""
+temporary_file_template="${TMPDIR:-/tmp}/dotnet.XXXXXXXXX"
+
+channel="LTS"
+version="Latest"
+json_file=""
+install_dir="<auto>"
+architecture="<auto>"
+dry_run=false
+no_path=false
+azure_feed=""
+uncached_feed=""
+feed_credential=""
+verbose=false
+runtime=""
+runtime_id=""
+quality=""
+internal=false
+override_non_versioned_files=true
+non_dynamic_parameters=""
+user_defined_os=""
+
+while [ $# -ne 0 ]
+do
+    name="$1"
+    case "$name" in
+        -c|--channel|-[Cc]hannel)
+            shift
+            channel="$1"
+            ;;
+        -v|--version|-[Vv]ersion)
+            shift
+            version="$1"
+            ;;
+        -q|--quality|-[Qq]uality)
+            shift
+            quality="$1"
+            ;;
+        --internal|-[Ii]nternal)
+            internal=true
+            non_dynamic_parameters+=" $name"
+            ;;
+        -i|--install-dir|-[Ii]nstall[Dd]ir)
+            shift
+            install_dir="$1"
+            ;;
+        --arch|--architecture|-[Aa]rch|-[Aa]rchitecture)
+            shift
+            architecture="$1"
+            ;;
+        --os|-[Oo][SS])
+            shift
+            user_defined_os="$1"
+            ;;
+        --shared-runtime|-[Ss]hared[Rr]untime)
+            say_warning "The --shared-runtime flag is obsolete and may be removed in a future version of this script. The recommended usage is to specify '--runtime dotnet'."
+            if [ -z "$runtime" ]; then
+                runtime="dotnet"
+            fi
+            ;;
+        --runtime|-[Rr]untime)
+            shift
+            runtime="$1"
+            if [[ "$runtime" != "dotnet" ]] && [[ "$runtime" != "aspnetcore" ]]; then
+                say_err "Unsupported value for --runtime: '$1'. Valid values are 'dotnet' and 'aspnetcore'."
+                if [[ "$runtime" == "windowsdesktop" ]]; then
+                    say_err "WindowsDesktop archives are manufactured for Windows platforms only."
+                fi
+                exit 1
+            fi
+            ;;
+        --dry-run|-[Dd]ry[Rr]un)
+            dry_run=true
+            ;;
+        --no-path|-[Nn]o[Pp]ath)
+            no_path=true
+            non_dynamic_parameters+=" $name"
+            ;;
+        --verbose|-[Vv]erbose)
+            verbose=true
+            non_dynamic_parameters+=" $name"
+            ;;
+        --azure-feed|-[Aa]zure[Ff]eed)
+            shift
+            azure_feed="$1"
+            non_dynamic_parameters+=" $name "\""$1"\"""
+            ;;
+        --uncached-feed|-[Uu]ncached[Ff]eed)
+            shift
+            uncached_feed="$1"
+            non_dynamic_parameters+=" $name "\""$1"\"""
+            ;;
+        --feed-credential|-[Ff]eed[Cc]redential)
+            shift
+            feed_credential="$1"
+            #feed_credential should start with "?", for it to be added to the end of the link.
+            #adding "?" at the beginning of the feed_credential if needed.
+            [[ -z "$(echo $feed_credential)" ]] || [[ $feed_credential == \?* ]] || feed_credential="?$feed_credential"
+            ;;
+        --runtime-id|-[Rr]untime[Ii]d)
+            shift
+            runtime_id="$1"
+            non_dynamic_parameters+=" $name "\""$1"\"""
+            say_warning "Use of --runtime-id is obsolete and should be limited to the versions below 2.1. To override architecture, use --architecture option instead. To override OS, use --os option instead."
+            ;;
+        --jsonfile|-[Jj][Ss]on[Ff]ile)
+            shift
+            json_file="$1"
+            ;;
+        --skip-non-versioned-files|-[Ss]kip[Nn]on[Vv]ersioned[Ff]iles)
+            override_non_versioned_files=false
+            non_dynamic_parameters+=" $name"
+            ;;
+        --keep-zip|-[Kk]eep[Zz]ip)
+            keep_zip=true
+            non_dynamic_parameters+=" $name"
+            ;;
+        --zip-path|-[Zz]ip[Pp]ath)
+            shift
+            zip_path="$1"
+            ;;
+        -?|--?|-h|--help|-[Hh]elp)
+            script_name="dotnet-install.sh"
+            echo ".NET Tools Installer"
+            echo "Usage:"
+            echo "       # Install a .NET SDK of a given Quality from a given Channel"
+            echo "       $script_name [-c|--channel <CHANNEL>] [-q|--quality <QUALITY>]"
+            echo "       # Install a .NET SDK of a specific public version"
+            echo "       $script_name [-v|--version <VERSION>]"
+            echo "       $script_name -h|-?|--help"
+            echo ""
+            echo "$script_name is a simple command line interface for obtaining dotnet cli."
+            echo "    Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:"
+            echo "    - The SDK needs to be installed without user interaction and without admin rights."
+            echo "    - The SDK installation doesn't need to persist across multiple CI runs."
+            echo "    To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer."
+            echo ""
+            echo "Options:"
+            echo "  -c,--channel <CHANNEL>         Download from the channel specified, Defaults to \`$channel\`."
+            echo "      -Channel"
+            echo "          Possible values:"
+            echo "          - STS - the most recent Standard Term Support release"
+            echo "          - LTS - the most recent Long Term Support release"
+            echo "          - 2-part version in a format A.B - represents a specific release"
+            echo "              examples: 2.0; 1.0"
+            echo "          - 3-part version in a format A.B.Cxx - represents a specific SDK release"
+            echo "              examples: 5.0.1xx, 5.0.2xx."
+            echo "              Supported since 5.0 release"
+            echo "          Warning: Value 'Current' is deprecated for the Channel parameter. Use 'STS' instead."
+            echo "          Note: The version parameter overrides the channel parameter when any version other than 'latest' is used."
+            echo "  -v,--version <VERSION>         Use specific VERSION, Defaults to \`$version\`."
+            echo "      -Version"
+            echo "          Possible values:"
+            echo "          - latest - the latest build on specific channel"
+            echo "          - 3-part version in a format A.B.C - represents specific version of build"
+            echo "              examples: 2.0.0-preview2-006120; 1.1.0"
+            echo "  -q,--quality <quality>         Download the latest build of specified quality in the channel."
+            echo "      -Quality"
+            echo "          The possible values are: daily, preview, GA."
+            echo "          Works only in combination with channel. Not applicable for STS and LTS channels and will be ignored if those channels are used." 
+            echo "          Supported since 5.0 release." 
+            echo "          Note: The version parameter overrides the channel parameter when any version other than 'latest' is used, and therefore overrides the quality."
+            echo "  --internal,-Internal               Download internal builds. Requires providing credentials via --feed-credential parameter."
+            echo "  --feed-credential <FEEDCREDENTIAL> Token to access Azure feed. Used as a query string to append to the Azure feed."
+            echo "      -FeedCredential                This parameter typically is not specified."
+            echo "  -i,--install-dir <DIR>             Install under specified location (see Install Location below)"
+            echo "      -InstallDir"
+            echo "  --architecture <ARCHITECTURE>      Architecture of dotnet binaries to be installed, Defaults to \`$architecture\`."
+            echo "      --arch,-Architecture,-Arch"
+            echo "          Possible values: x64, arm, arm64, s390x, ppc64le and loongarch64"
+            echo "  --os <system>                    Specifies operating system to be used when selecting the installer."
+            echo "          Overrides the OS determination approach used by the script. Supported values: osx, linux, linux-musl, freebsd, rhel.6."
+            echo "          In case any other value is provided, the platform will be determined by the script based on machine configuration."
+            echo "          Not supported for legacy links. Use --runtime-id to specify platform for legacy links."
+            echo "          Refer to: https://aka.ms/dotnet-os-lifecycle for more information."
+            echo "  --runtime <RUNTIME>                Installs a shared runtime only, without the SDK."
+            echo "      -Runtime"
+            echo "          Possible values:"
+            echo "          - dotnet     - the Microsoft.NETCore.App shared runtime"
+            echo "          - aspnetcore - the Microsoft.AspNetCore.App shared runtime"
+            echo "  --dry-run,-DryRun                  Do not perform installation. Display download link."
+            echo "  --no-path, -NoPath                 Do not set PATH for the current process."
+            echo "  --verbose,-Verbose                 Display diagnostics information."
+            echo "  --azure-feed,-AzureFeed            For internal use only."
+            echo "                                     Allows using a different storage to download SDK archives from."
+            echo "  --uncached-feed,-UncachedFeed      For internal use only."
+            echo "                                     Allows using a different storage to download SDK archives from."
+            echo "  --skip-non-versioned-files         Skips non-versioned files if they already exist, such as the dotnet executable."
+            echo "      -SkipNonVersionedFiles"
+            echo "  --jsonfile <JSONFILE>              Determines the SDK version from a user specified global.json file."
+            echo "                                     Note: global.json must have a value for 'SDK:Version'"
+            echo "  --keep-zip,-KeepZip                If set, downloaded file is kept."
+            echo "  --zip-path, -ZipPath               If set, downloaded file is stored at the specified path."
+            echo "  -?,--?,-h,--help,-Help             Shows this help message"
+            echo ""
+            echo "Install Location:"
+            echo "  Location is chosen in following order:"
+            echo "    - --install-dir option"
+            echo "    - Environmental variable DOTNET_INSTALL_DIR"
+            echo "    - $HOME/.dotnet"
+            exit 0
+            ;;
+        *)
+            say_err "Unknown argument \`$name\`"
+            exit 1
+            ;;
+    esac
+
+    shift
+done
+
+say_verbose "Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:"
+say_verbose "- The SDK needs to be installed without user interaction and without admin rights."
+say_verbose "- The SDK installation doesn't need to persist across multiple CI runs."
+say_verbose "To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.\n"
+
+if [ "$internal" = true ] && [ -z "$(echo $feed_credential)" ]; then
+    message="Provide credentials via --feed-credential parameter."
+    if [ "$dry_run" = true ]; then
+        say_warning "$message"
+    else
+        say_err "$message"
+        exit 1
+    fi
+fi
+
+check_min_reqs
+calculate_vars
+# generate_regular_links call below will 'exit' if the determined version is already installed.
+generate_download_links
+
+if [[ "$dry_run" = true ]]; then
+    print_dry_run
+    exit 0
+fi
+
+install_dotnet
+
+bin_path="$(get_absolute_path "$(combine_paths "$install_root" "$bin_folder_relative_path")")"
+if [ "$no_path" = false ]; then
+    say "Adding to current process PATH: \`$bin_path\`. Note: This change will be visible only when sourcing script."
+    export PATH="$bin_path":"$PATH"
+else
+    say "Binaries of dotnet can be found in $bin_path"
+fi
+
+say "Note that the script does not resolve dependencies during installation."
+say "To check the list of dependencies, go to https://learn.microsoft.com/dotnet/core/install, select your operating system and check the \"Dependencies\" section."
+say "Installation finished successfully."


### PR DESCRIPTION
Fixes Codex internal scanning.

Intentionally omitted auto-updating. We do not have infrastructure for this yet. It can be manually synced when updating upstream changes.